### PR TITLE
Remove SecureStrings.hs from the project

### DIFF
--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -52,10 +52,6 @@ library
                      Util.Database
                      Util.Data
 
-    if !flag(dev) && !flag(library-only)
-        exposed-modules:
-            SecureStrings
-
     if flag(dev) || flag(library-only)
         cpp-options:   -DDEVELOPMENT
         ghc-options:   -Wall -fwarn-tabs -O0

--- a/Carnap-Server/Settings.hs
+++ b/Carnap-Server/Settings.hs
@@ -8,10 +8,6 @@ module Settings where
 
 import ClassyPrelude.Yesod
 import Control.Exception           (throw)
-#if DEVELOPMENT
-#else
-import SecureStrings               (googleApiKey, googleSecret)
-#endif
 import Data.Aeson                  (Result (..), fromJSON, withObject, (.!=), (.:?))
 import Data.FileEmbed              (embedFile)
 import Data.Yaml                   (decodeEither')
@@ -76,12 +72,8 @@ instance FromJSON AppSettings where
     parseJSON = withObject "AppSettings" $ \o -> do
 #if DEVELOPMENT
         let appDevel = True
-            appKey = ""
-            appSecret = ""
 #else
         let appDevel = False
-            appKey = googleApiKey
-            appSecret = googleSecret
 #endif
         appStaticDir              <- o .: "static-dir"
         appDatabaseConf           <- o .: "database"
@@ -101,6 +93,8 @@ instance FromJSON AppSettings where
 
         appCopyright              <- o .: "copyright"
         appAnalytics              <- o .:? "analytics"
+        appKey                    <- o .:? "google-api-key"   .!= ""
+        appSecret                 <- o .:? "google-secret"    .!= ""
 
         return AppSettings {..}
 

--- a/Carnap-Server/config/settings.yml
+++ b/Carnap-Server/config/settings.yml
@@ -39,4 +39,7 @@ sqlite: true
 data-root: "_env:DATAROOT:/var/lib/carnap"
 book-root: "_env:BOOKROOT:/var/lib/carnap/book/"
 
+google-api-key: "_env:GOOGLEKEY"
+google-secret: "_env:GOOGLESECRET"
+
 #analytics: UA-YOURCODE


### PR DESCRIPTION
This file adds confusion while compiling for production and meant that we were shipping secrets in the production binaries, which is problematic for dockerization (my current project) if we intend to publish an image on a public registry. It has been replaced with environment variables: GOOGLEKEY and GOOGLESECRET, replacing the fields that were previously in
SecureStrings.hs. It can also be configured in settings.yml with the caveat that doing so, again, results in shipping secrets in the production binaries.

This is a breaking change for existing users.

We should disable authentication when there are no keys configured (see #116), which is the next step in the auth project :)