### PR TITLE
Update Carnap-Server to newer dependencies

### DIFF
--- a/Carnap-Server/Application.hs
+++ b/Carnap-Server/Application.hs
@@ -48,7 +48,7 @@ import Handler.Command
 import Handler.Hashed
 import Handler.Register
 import Handler.Rule
-import Handler.Instuctor
+import Handler.Instructor
 import Handler.Admin
 import Handler.Assignment
 import Handler.Document

--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -25,7 +25,7 @@ library
                      Handler.Info
                      Handler.Register
                      Handler.User
-                     Handler.Instuctor
+                     Handler.Instructor
                      Handler.Admin
                      Handler.Chapter
                      Handler.Book
@@ -84,25 +84,25 @@ library
                  , yesod-static                  >=1.6 && <1.7
                  , yesod-form                    >=1.6 && <1.7
                  , yesod-markdown                >= 0.12
-                 , classy-prelude                >=1.4 && <1.5
-                 , classy-prelude-conduit        >=1.4 && <1.5
-                 , classy-prelude-yesod          >=1.4 && <1.5
+                 , classy-prelude                >=1.4 && <1.6
+                 , classy-prelude-conduit        >=1.4 && <1.6
+                 , classy-prelude-yesod          >=1.4 && <1.6
                  , bytestring                    >=0.9 && <0.11
                  , text                          >=0.11 && <2.0
-                 , persistent                    >=2.8 && <2.9
-                 , persistent-postgresql         >=2.8 && <2.9
+                 , persistent                    >=2.8 && <2.10
+                 , persistent-postgresql         >=2.8 && <2.10
                  , persistent-sqlite
                  , persistent-template           >= 2.5        && < 2.9
                  , template-haskell
                  , shakespeare                   >= 2.0        && < 2.1
                  , monad-control                 >= 0.3        && < 1.1
                  , wai-extra                     >= 3.0        && < 3.1
-                 , yaml                          >= 0.8        && < 0.9
+                 , yaml                          >= 0.8        && < 0.12
                  , http-conduit                  >= 2.3        && < 2.4
                  , directory                     >= 1.1        && < 1.4
-                 , warp                          >= 3.0        && < 3.3
+                 , warp                          >= 3.0        && < 3.4
                  , data-default
-                 , aeson                         >= 0.6        && < 1.4
+                 , aeson                         >= 0.6        && < 1.5
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4
                  , fast-logger                   >= 2.2        && < 2.5

--- a/Carnap-Server/Handler/Admin.hs
+++ b/Carnap-Server/Handler/Admin.hs
@@ -4,7 +4,7 @@ module Handler.Admin where
 import Import
 import Util.Data
 import Util.Database
-import Handler.Instuctor (dateDisplay)
+import Handler.Instructor (dateDisplay)
 import Yesod.Form.Bootstrap3
 import Yesod.Form.Jquery
 import Text.Blaze.Html (toMarkup)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,18 @@
 flags: {}
 extra-package-dbs: []
-extra-deps: 
-    - yesod-markdown-0.12.4
-    - yesod-auth-oauth2-0.6.1.0
-    - hoauth2-1.8.4
-    - uri-bytestring-aeson-0.1.0.7
+extra-deps:
+    - yesod-markdown-0.12.6.3
+    - yesod-auth-oauth2-0.6.1.2
+    - hoauth2-1.8.9
+    - uri-bytestring-aeson-0.1.0.8
+    - diagrams-builder-0.8.0.5
+    - haskell-src-exts-simple-1.22.0.0
+    - haskell-src-exts-1.22.0
 
 packages:
 - Carnap/
 - Carnap-Server/
 - Carnap-Client/
 #resolver: lts-6.25
-resolver: lts-12.16
+#resolver: lts-12.26
+resolver: lts-14.27


### PR DESCRIPTION
This entailed resolving a bunch of instances of yesodweb/yesod#1569 by adding explicit error handling (HandlerFor is no longer a ReaderT and thus doesn't have a MonadFail).

I also fixed a typo in `Instructor.hs`'s filename. I encountered some technical debt while doing this PR: there are a lot of functions that don't have declarations, which caused the compile errors to be of low quality.

Fixes #126. Sorry if I interfered with your fix, I wasn't initially planning on doing this one myself, but it was blocking my other work.