### PR TITLE
remove diagrams-lib dependency from Carnap-GHCJS

### DIFF
--- a/Carnap-GHCJS/Carnap-GHCJS.cabal
+++ b/Carnap-GHCJS/Carnap-GHCJS.cabal
@@ -35,8 +35,6 @@ library
                          , lens
                          , ghcjs-dom == 0.2.4.0
                          , containers
-                         , diagrams-core
-                         , diagrams-svg
                          , mtl
                          , parsec
                          , Carnap

--- a/Carnap-GHCJS/Carnap-GHCJS.cabal
+++ b/Carnap-GHCJS/Carnap-GHCJS.cabal
@@ -53,8 +53,6 @@ library
                          , lens
                          , ghcjs-dom == 0.2.4.0
                          , containers
-                         , diagrams-core
-                         , diagrams-svg
                          , mtl
                          , parsec
                          , Carnap

--- a/Carnap-GHCJS/Carnap-GHCJS.nix
+++ b/Carnap-GHCJS/Carnap-GHCJS.nix
@@ -1,7 +1,6 @@
 { mkDerivation, aeson, base, blaze-html, bytestring, Carnap
-, Carnap-Client, containers, diagrams-core, diagrams-svg, ghcjs-dom
-, hashable, lens, mtl, parsec, shakespeare, stdenv, tagsoup, text
-, transformers
+, Carnap-Client, containers, ghcjs-dom, hashable, lens, mtl, parsec
+, shakespeare, stdenv, tagsoup, text, transformers
 }:
 mkDerivation {
   pname = "Carnap-GHCJS";
@@ -11,8 +10,8 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson base blaze-html bytestring Carnap Carnap-Client containers
-    diagrams-core diagrams-svg ghcjs-dom hashable lens mtl parsec
-    shakespeare tagsoup text transformers
+    ghcjs-dom hashable lens mtl parsec shakespeare tagsoup text
+    transformers
   ];
   executableHaskellDepends = [ base ];
   description = "GHCJS-compiled Components for Carnap Proof Assistant";

--- a/Carnap-GHCJS/Carnap-GHCJS.nix
+++ b/Carnap-GHCJS/Carnap-GHCJS.nix
@@ -15,7 +15,6 @@ mkDerivation {
     shakespeare tagsoup text transformers
   ];
   executableHaskellDepends = [ base ];
-  testHaskellDepends = [ base Carnap ghcjs-dom ];
   description = "GHCJS-compiled Components for Carnap Proof Assistant";
   license = stdenv.lib.licenses.gpl3;
 }


### PR DESCRIPTION
As requested on the mailing list; fixes the Carnap-GHCJS build on macOS.