### PR TITLE
Update broken pango, cairo and glib dependencies on macOS

### DIFF
--- a/Carnap-GHCJS/Carnap-GHCJS.cabal
+++ b/Carnap-GHCJS/Carnap-GHCJS.cabal
@@ -35,8 +35,6 @@ library
                          , lens
                          , ghcjs-dom == 0.2.4.0
                          , containers
-                         , diagrams-core
-                         , diagrams-svg
                          , mtl
                          , parsec
                          , Carnap

--- a/Carnap-GHCJS/Carnap-GHCJS.cabal
+++ b/Carnap-GHCJS/Carnap-GHCJS.cabal
@@ -53,8 +53,6 @@ library
                          , lens
                          , ghcjs-dom == 0.2.4.0
                          , containers
-                         , diagrams-core
-                         , diagrams-svg
                          , mtl
                          , parsec
                          , Carnap

--- a/Carnap-GHCJS/Carnap-GHCJS.nix
+++ b/Carnap-GHCJS/Carnap-GHCJS.nix
@@ -1,7 +1,6 @@
 { mkDerivation, aeson, base, blaze-html, bytestring, Carnap
-, Carnap-Client, containers, diagrams-core, diagrams-svg, ghcjs-dom
-, hashable, lens, mtl, parsec, shakespeare, stdenv, tagsoup, text
-, transformers
+, Carnap-Client, containers, ghcjs-dom, hashable, lens, mtl, parsec
+, shakespeare, stdenv, tagsoup, text, transformers
 }:
 mkDerivation {
   pname = "Carnap-GHCJS";
@@ -11,8 +10,8 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     aeson base blaze-html bytestring Carnap Carnap-Client containers
-    diagrams-core diagrams-svg ghcjs-dom hashable lens mtl parsec
-    shakespeare tagsoup text transformers
+    ghcjs-dom hashable lens mtl parsec shakespeare tagsoup text
+    transformers
   ];
   executableHaskellDepends = [ base ];
   description = "GHCJS-compiled Components for Carnap Proof Assistant";

--- a/Carnap-GHCJS/Carnap-GHCJS.nix
+++ b/Carnap-GHCJS/Carnap-GHCJS.nix
@@ -15,7 +15,6 @@ mkDerivation {
     shakespeare tagsoup text transformers
   ];
   executableHaskellDepends = [ base ];
-  testHaskellDepends = [ base Carnap ghcjs-dom ];
   description = "GHCJS-compiled Components for Carnap Proof Assistant";
   license = stdenv.lib.licenses.gpl3;
 }

--- a/nix/cairo.nix
+++ b/nix/cairo.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, array, base, bytestring, Cabal, cairo
+, gtk2hs-buildtools, mtl, stdenv, text, utf8-string
+}:
+mkDerivation {
+  pname = "cairo";
+  version = "0.13.8.1";
+  sha256 = "1316412d51556205cfc097a354eddf0e51f4d319cde0498626a2854733f4f3c2";
+  enableSeparateDataOutput = true;
+  setupHaskellDepends = [ base Cabal gtk2hs-buildtools ];
+  libraryHaskellDepends = [
+    array base bytestring mtl text utf8-string
+  ];
+  libraryPkgconfigDepends = [ cairo ];
+  homepage = "http://projects.haskell.org/gtk2hs/";
+  description = "Binding to the Cairo library";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nix/gitignore.nix
+++ b/nix/gitignore.nix
@@ -1,0 +1,14 @@
+{}:
+self: super:
+  let
+    gitignoreSrc = super.fetchFromGitHub {
+      owner = "hercules-ci";
+      repo = "gitignore";
+      rev = "647d0821b590ee96056f4593640534542d8700e5";
+      sha256 = "sha256:0ks37vclz2jww9q0fvkk9jyhscw0ial8yx2fpakra994dm12yy1d";
+    };
+  in {
+    lib = super.lib // {
+      inherit (import gitignoreSrc { inherit (super) lib; }) gitignoreSource;
+    };
+  }

--- a/nix/glib.nix
+++ b/nix/glib.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, bytestring, Cabal, containers, glib
+, gtk2hs-buildtools, stdenv, text, utf8-string
+}:
+mkDerivation {
+  pname = "glib";
+  version = "0.13.8.1";
+  sha256 = "dcd028ac6d4a7476c14585be1d845b8c4aea4c389f34e809ed1a8df7425c1a9c";
+  setupHaskellDepends = [ base Cabal gtk2hs-buildtools ];
+  libraryHaskellDepends = [
+    base bytestring containers text utf8-string
+  ];
+  libraryPkgconfigDepends = [ glib ];
+  homepage = "http://projects.haskell.org/gtk2hs/";
+  description = "Binding to the GLIB library for Gtk2Hs";
+  license = stdenv.lib.licenses.lgpl21;
+}

--- a/nix/pango.nix
+++ b/nix/pango.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, array, base, Cabal, cairo, containers, directory
+, filepath, glib, gtk2hs-buildtools, mtl, pango, pretty, process
+, stdenv, text
+}:
+mkDerivation {
+  pname = "pango";
+  version = "0.13.8.1";
+  sha256 = "40a67a56687969cee9dd4cc94a8a3d0beb5ea687c8a2f3da552feb915453c82f";
+  enableSeparateDataOutput = true;
+  setupHaskellDepends = [ base Cabal filepath gtk2hs-buildtools ];
+  libraryHaskellDepends = [
+    array base cairo containers directory glib mtl pretty process text
+  ];
+  libraryPkgconfigDepends = [ pango ];
+  homepage = "http://projects.haskell.org/gtk2hs/";
+  description = "Binding to the Pango text rendering engine";
+  license = stdenv.lib.licenses.lgpl21;
+}

--- a/server.nix
+++ b/server.nix
@@ -13,6 +13,19 @@
             haskell-src-exts-simple = doJailbreak oldpkgs.haskell-src-exts-simple;
             diagrams-builder = doJailbreak oldpkgs.diagrams-builder;
 
+            # updates pango, glib, cairo to a version including
+            # https://github.com/gtk2hs/gtk2hs/commit/1cf2f9bff2427d39986e32880d1383cfff49ab0e
+            # remove once nixpkgs.haskell.packages.ghc865.glib version >= 0.13.8.1
+            # i.e. most likely when we update past nixpkgs-20.03 (pending nixpkgs
+            # unstable having a working ghcjs) as pango-0.13.8.1 is in unstable
+            # already
+            # I checked this with:
+            # $ nix-instantiate '<nixpkgs-unstable>' -A haskell.packages.ghc865.pango
+            # /nix/store/aqvkx9yd2s5m0svki3fr84klq6fyw6dw-pango-0.13.8.1.drv
+            glib = oldpkgs.callPackage ./nix/glib.nix { inherit (self) glib; };
+            pango = oldpkgs.callPackage ./nix/pango.nix { inherit (self) pango; };
+            cairo = oldpkgs.callPackage ./nix/cairo.nix { inherit (self) cairo; };
+
             # ghcjs-dom-0.2.4.0 (released 2016)
             # using `ghc` native dependencies
             # currently broken: ghcjs-dom needs to be updated to a newer


### PR DESCRIPTION
This should fix *that* problem with the build on macOS, whether it will fix the
entire build, it is yet to see.

This minor hack is temporary and will be able to be removed when nixos-20.09
comes out, assuming that they have a working ghcjs (which is not the case in
the development version).

@dsanson can you check if this fixes the issue you were having building the
server?