### PR TITLE
Dockerize Carnap & add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,16 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: cachix/cachix-action@v6
       with:
-        name: jade-carnap
+        name: carnap
         # skip pushing to cachix if this is NOT a push to a branch (i.e. it is a PR)
         skipPush: ${{ github.event_name != 'push' }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - uses: cachix/cachix-action@v6
+      with:
+        name: jade-carnap
+        # temporarily use the jade-carnap cachix instance while we haven't got
+        # a full build on the carnap one
+        skipPush: true
     # this pulls in client also
     - run: nix-build -A server
 
@@ -38,9 +44,14 @@ jobs:
     - run: nix-shell -p skopeo --run "skopeo login docker.pkg.github.com -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}"
     - uses: cachix/cachix-action@v6
       with:
-        name: jade-carnap
+        name: carnap
         # the docker image artifacts are really big and not terribly useful for deployment
         skipPush: true
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - uses: cachix/cachix-action@v6
+      with:
+        name: jade-carnap
+        # temporary, as above
+        skipPush: true
     - run: nix-shell -p skopeo --run "skopeo copy docker-archive:$(nix-build release.nix --arg hasKvm false -A docker --no-out-link) docker://$(echo ${IMG_REF} | envsubst | tr 'A-Z' 'a-z')"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: Automatically build Carnap and Carnap-GHCJS
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v10
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v6
+      with:
+        name: jade-carnap
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    # this pulls in client also
+    - run: nix-build -A server
+    - run: nix-shell --run "echo OK"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     - uses: cachix/install-nix-action@v10
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - run: nix-shell -p skopeo --run "skopeo login docker.pkg.github.com -u lf- -p ${{ secrets.GH_PACKAGES_TOKEN }}"
+    - run: nix-shell -p skopeo --run "skopeo login docker.pkg.github.com -u ${{ github.repository_owner }} -p ${{ secrets.GITHUB_TOKEN }}"
     - uses: cachix/cachix-action@v6
       with:
         name: jade-carnap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,5 +26,5 @@ jobs:
       with:
         name: jade-carnap
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-build release.nix --attr hasKvm false -A docker
+    - run: nix-build release.nix --arg hasKvm false -A docker
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,16 +18,20 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     env:
-      IMG_REF: "docker.pkg.github.com/${GITHUB_REPOSITORY}:${GITHUB_SHA}"
+      IMG_REF: "docker.pkg.github.com/${GITHUB_REPOSITORY}/carnap:${GITHUB_SHA}"
+      # GitHub Actions has a broken default for this
+      XDG_RUNTIME_DIR: "${HOME}/run"
     steps:
+    - run: 'mkdir -p "${XDG_RUNTIME_DIR}"'
+    - run: "echo url: docker://$(echo ${IMG_REF} | envsubst | tr 'A-Z' 'a-z')"
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v10
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - run: nix-shell -p skopeo --run "skopeo login -u lf- -p ${{ secrets.GH_PACKAGES_TOKEN }}"
+    - run: nix-shell -p skopeo --run "skopeo login docker.pkg.github.com -u lf- -p ${{ secrets.GH_PACKAGES_TOKEN }}"
     - uses: cachix/cachix-action@v6
       with:
         name: jade-carnap
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-shell -p skopeo --run "skopeo copy docker-image://$(nix-build release.nix --arg hasKvm false -A docker --no-out-link) docker://${IMG_REF}"
+    - run: nix-shell -p skopeo --run "skopeo copy docker-archive:$(nix-build release.nix --arg hasKvm false -A docker --no-out-link) docker://$(echo ${IMG_REF} | envsubst | tr 'A-Z' 'a-z')"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,10 @@ name: Automatically build Carnap and Carnap-GHCJS
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v10

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: Automatically build Carnap and Carnap-GHCJS
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -14,11 +14,15 @@ jobs:
     - uses: cachix/cachix-action@v6
       with:
         name: jade-carnap
+        # skip pushing to cachix if this is NOT a push to a branch (i.e. it is a PR)
+        skipPush: '${{ github.event_name != "push" }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     # this pulls in client also
     - run: nix-build -A server
 
   docker-build:
+    # only build deployable images on master branch
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     env:
       IMG_REF: "docker.pkg.github.com/${GITHUB_REPOSITORY}/carnap:${GITHUB_SHA}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,14 +17,17 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
+    env:
+      IMG_REF: "docker.pkg.github.com/${GITHUB_REPOSITORY}:${GITHUB_SHA}"
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v10
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-shell -p skopeo --run "skopeo login -u lf- -p ${{ secrets.GH_PACKAGES_TOKEN }}"
     - uses: cachix/cachix-action@v6
       with:
         name: jade-carnap
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix-build release.nix --arg hasKvm false -A docker
+    - run: nix-shell -p skopeo --run "skopeo copy docker-image://$(nix-build release.nix --arg hasKvm false -A docker --no-out-link) docker://${IMG_REF}"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,4 +14,3 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     # this pulls in client also
     - run: nix-build -A server
-    - run: nix-shell --run "echo OK"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,3 +14,17 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     # this pulls in client also
     - run: nix-build -A server
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v10
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v6
+      with:
+        name: jade-carnap
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - run: nix-build release.nix --attr hasKvm false -A docker
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       with:
         name: jade-carnap
         # skip pushing to cachix if this is NOT a push to a branch (i.e. it is a PR)
-        skipPush: '${{ github.event_name != "push" }}'
+        skipPush: ${{ github.event_name != 'push' }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     # this pulls in client also
     - run: nix-build -A server
@@ -25,7 +25,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     env:
-      IMG_REF: "docker.pkg.github.com/${GITHUB_REPOSITORY}/carnap:${GITHUB_SHA}"
+      IMG_REF: "docker.pkg.github.com/${GITHUB_REPOSITORY}/carnap:latest"
       # GitHub Actions has a broken default for this
       XDG_RUNTIME_DIR: "${HOME}/run"
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ jobs:
     - uses: cachix/cachix-action@v6
       with:
         name: jade-carnap
+        # the docker image artifacts are really big and not terribly useful for deployment
+        skipPush: true
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: nix-shell -p skopeo --run "skopeo copy docker-archive:$(nix-build release.nix --arg hasKvm false -A docker --no-out-link) docker://$(echo ${IMG_REF} | envsubst | tr 'A-Z' 'a-z')"
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ server-out
 result
 cabal.project.local
 .cabal-fake-client-out/
+docker-out

--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -58,9 +58,9 @@ instance Yesod App where
 
     -- Store session data on the client in encrypted cookies,
     -- default session idle timeout is 120 minutes
-    makeSessionBackend _ = Just <$> defaultClientSessionBackend
-        120    -- timeout in minutes
-        "config/client_session_key.aes"
+    makeSessionBackend app = Just <$> defaultClientSessionBackend
+            120    -- timeout in minutes
+            ((appDataRoot $ appSettings app) </> "client_session_key.aes")
 
     -- Yesod Middleware allows you to run code before and after each handler function.
     -- The defaultYesodMiddleware adds the response header "Vary: Accept, Accept-Language" and performs authorization checks.

--- a/Carnap-Server/Handler/User.hs
+++ b/Carnap-Server/Handler/User.hs
@@ -11,7 +11,6 @@ import Data.Time
 import Data.List ((!!),elemIndex)
 import Data.Time.Zones
 import Data.Time.Zones.All
-import Data.Aeson (decodeStrict)
 import Util.Data
 import Util.Database
 import qualified Data.Map as M
@@ -303,12 +302,13 @@ personalInfo (UserData firstname lastname maybeCourseId maybeInstructorId _) mco
                                 Edit
                             |]
 
-updateUserDataForm (UserData firstname lastname maybeCourseId _ _) classes = renderBootstrap3 BootstrapBasicForm $ (,,)
+updateUserDataForm (UserData firstname lastname _ _ _) classes = renderBootstrap3 BootstrapBasicForm $ (,,)
             <$> aopt (selectFieldList classnames) (bfs ("Class" :: Text)) Nothing
             <*> areq textField (bfs ("First Name"::Text)) (Just firstname)
             <*> areq textField (bfs ("Last Name"::Text)) (Just lastname)
     where classnames = map (\theclass -> (courseTitle . entityVal $ theclass, theclass)) classes
 
+nouserPage :: WidgetT site m ()
 nouserPage = [whamlet|
              <div.container>
                 <p> This user does not exist

--- a/Carnap-Server/config/settings-example.yml
+++ b/Carnap-Server/config/settings-example.yml
@@ -34,12 +34,14 @@ database:
 copyright: Copyright 2015-2020 G. Leach-Krouse <gleachkr@ksu.edu> and J. Ehrlich
 
 #set to true if you want to run without a postgres installation
-sqlite: true
+sqlite: "_env:SQLITE:true"
 
 data-root: "_env:DATAROOT:/var/lib/carnap"
 book-root: "_env:BOOKROOT:/var/lib/carnap/book/"
 
+# Google API keys for Google based login
 google-api-key: "_env:GOOGLEKEY"
 google-secret: "_env:GOOGLESECRET"
 
-#analytics: UA-YOURCODE
+# UA-YOURCODE e.g. UA-12345
+analytics: "_env:GOOGLEANALYTICS"

--- a/README.md
+++ b/README.md
@@ -128,15 +128,54 @@ $ nix-shell -A ghcjsShell
 $ cabal --project-file=cabal-ghcjs.project --builddir=dist-ghcjs new-build all
 ```
 
+## Deployment
+
+### Docker
+
+There is experimental Docker support for Carnap. Currently, diagrams support is
+broken, which impacts some chapters of the Carnap textbook.
+
+Images are available via the GitHub container registry at
+`docker.pkg.github.com/gleachkr/carnap/carnap:GITREVISION`.
+
+Note that Carnap docker images are about 3GB uncompressed and about 500MB to
+download.
+
+If you'd like to build an image locally for development/testing, run:
+
+```
+nix-build release.nix -A docker -o docker-out
+```
+
+then load it into the docker daemon with:
+
+```
+docker image load -i docker-out
+```
+
+It will be available under the image name `carnap:latest`.
+
+To run Carnap under docker:
+
+```
+docker run --rm -v carnap_data:/data -e APPROOT=http://your-app-root.com
+```
+
+For production deployment, set the environment variable SQLITE=false and supply
+`PGUSER`, `PGPASS`, `PGHOST`, and if required, `PGPORT` and `PGDATABASE` for
+your postgresql database instance.
+
+The docker building setup does not require KVM support in the host kernel, and
+if you wish to build your images on a machine without it, run nix-build with
+the added argument `--arg hasKvm false`.
+
 ## Maintainer information
 
-### Pushing to Cachix
+### CI requirements
 
-This will likely be obviated in the future by doing this step in CI.
-
-```
-$ nix-build -A server | cachix push jade-carnap
-```
+CI requires that a Cachix signing key for the Cachix cache be supplied in the
+`CACHIX_SIGNING_KEY` Secret in the GitHub repository settings for artifacts to
+be pushed to Cachix.
 
 ### Generate the `.nix` files in a subproject
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ from @lf-'s [Cachix](https://cachix.org/) instance. To use it:
 $ # Install Cachix:
 $ nix-env -iA cachix -f https://cachix.org/api/v1/install
 $ # Use the Carnap Cachix
-$ cachix use jade-carnap
+$ cachix use carnap
 ```
 
 Then build as normal.
@@ -136,7 +136,7 @@ There is experimental Docker support for Carnap. Currently, diagrams support is
 broken, which impacts some chapters of the Carnap textbook.
 
 Images are available via the GitHub container registry at
-`docker.pkg.github.com/gleachkr/carnap/carnap:GITREVISION`.
+`docker.pkg.github.com/carnap/carnap/carnap:latest`.
 
 Note that Carnap docker images are about 3GB uncompressed and about 500MB to
 download.

--- a/client.nix
+++ b/client.nix
@@ -1,6 +1,6 @@
 { ghcjsVer ? "ghcjs" }:
   self: super:
-  let dontCheck = super.haskell.lib.dontCheck;
+  let inherit (super.haskell.lib) dontCheck withGitignore;
   in {
     haskell = super.haskell // {
       packages = super.haskell.packages // {
@@ -21,9 +21,13 @@
             # ghcjs-dom-0.2.4.0 (released 2016)
             ghcjs-dom = oldpkgs.callPackage ./nix/ghcjs-dom-ghcjs.nix { };
 
-            Carnap = oldpkgs.callPackage ./Carnap/Carnap.nix { };
-            Carnap-Client = oldpkgs.callPackage ./Carnap-Client/Carnap-Client.nix { };
-            Carnap-GHCJS = oldpkgs.callPackage ./Carnap-GHCJS/Carnap-GHCJS.nix { };
+            Carnap = withGitignore (oldpkgs.callPackage ./Carnap/Carnap.nix { });
+
+            Carnap-Client = withGitignore
+                (oldpkgs.callPackage ./Carnap-Client/Carnap-Client.nix { });
+
+            Carnap-GHCJS = withGitignore
+                (oldpkgs.callPackage ./Carnap-GHCJS/Carnap-GHCJS.nix { });
           };
         };
       };

--- a/default.nix
+++ b/default.nix
@@ -12,6 +12,7 @@ let
           allowBroken = true;
         };
         overlays = [
+          (import ./nix/gitignore.nix { })
           (import ./client.nix { inherit ghcjsVer; })
           (import ./server.nix { inherit ghcjsVer ghcVer; })
         ];

--- a/default.nix
+++ b/default.nix
@@ -27,7 +27,8 @@ let
         Cabal
         cabal-install
         ghcid
-        hasktags;
+        hasktags
+        yesod-bin;
     };
   };
 

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { ghcjsVer ? "ghcjs",
   ghcVer ? "ghc865",
+  profiling ? false,
 }:
 let
   nixpkgs = import (builtins.fetchTarball {
@@ -14,7 +15,7 @@ let
         overlays = [
           (import ./nix/gitignore.nix { })
           (import ./client.nix { inherit ghcjsVer; })
-          (import ./server.nix { inherit ghcjsVer ghcVer; })
+          (import ./server.nix { inherit ghcjsVer ghcVer profiling; })
         ];
       };
 

--- a/nix/gitignore.nix
+++ b/nix/gitignore.nix
@@ -7,8 +7,14 @@ self: super:
       rev = "647d0821b590ee96056f4593640534542d8700e5";
       sha256 = "sha256:0ks37vclz2jww9q0fvkk9jyhscw0ial8yx2fpakra994dm12yy1d";
     };
+    inherit (import gitignoreSrc { inherit (super) lib; }) gitignoreSource;
   in {
     lib = super.lib // {
-      inherit (import gitignoreSrc { inherit (super) lib; }) gitignoreSource;
+      inherit gitignoreSource;
+    };
+    haskell = super.haskell // {
+      lib = super.haskell.lib // {
+        withGitignore = drv: super.haskell.lib.overrideSrc drv { src = (gitignoreSource drv.src); };
+      };
     };
   }

--- a/nix/wrapped-qemu.nix
+++ b/nix/wrapped-qemu.nix
@@ -1,0 +1,20 @@
+{ pkgs }:
+with pkgs;
+stdenv.mkDerivation {
+  name = "wrapped-qemu";
+  # Remove first two arguments from qemu-kwm, namely "-host cpu"
+  buildCommand = ''
+    mkdir -p $out/bin
+    bins=$(find ${qemu_kvm}/bin -type f -not -name 'qemu-kvm')
+    for bin in $bins; do
+        ${coreutils}/bin/ln -s $bin $out/bin/
+    done
+    cat > $out/bin/qemu-kvm << EOF
+    #!${python}/bin/python
+    import sys, os
+    args = [sys.argv[0]] + sys.argv[3:]
+    os.execv('${qemu_kvm}/bin/qemu-kvm', args)
+    EOF
+    ${coreutils}/bin/chmod u+x $out/bin/qemu-kvm
+  '';
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,27 @@
+{}:
+  let inherit (import ./default.nix {}) client server nixpkgs;
+      inherit (nixpkgs.dockerTools) buildImage;
+  in {
+    inherit server;
+
+    docker = buildImage {
+      name = "Carnap";
+      tag = "latest";
+
+      # no base image, make a minimized image
+      contents = [ server ];
+      runAsRoot = ''
+        #!${nixpkgs.runtimeShell}
+        mkdir -p /data
+        cp -r ${server.out}/share/* /data
+      '';
+
+      config = {
+        Cmd = [ "/bin/Carnap-Server" ];
+        WorkingDir = "/data";
+        Volumes = {
+          "/data" = {};
+        };
+      };
+    };
+  }

--- a/release.nix
+++ b/release.nix
@@ -27,6 +27,7 @@
         # stuff dynamically under every single one of our "static" directories
         # >:(
         cp -r ${server.out}/share/* /data/
+        mkdir -p /data/book/cache
         mkdir -p /data/data
         exec Carnap-Server
         '';

--- a/release.nix
+++ b/release.nix
@@ -28,7 +28,7 @@
       tag = "latest";
 
       # no base image, make a minimized image
-      contents = [ server ];
+      contents = [ (nixpkgs.haskell.lib.justStaticExecutables server) ];
       runAsRoot = ''
         #!${nixpkgs.runtimeShell}
         echo runAsRoot::

--- a/release.nix
+++ b/release.nix
@@ -1,6 +1,25 @@
-{}:
+{ hasKvm ? true }:
   let inherit (import ./default.nix {}) client server nixpkgs;
-      inherit (nixpkgs.dockerTools) buildImage;
+      overrideSet = f: set: set // (f set);
+
+      # a hack to run the initial part of the docker build in software
+      # emulation if kvm is not available
+      # From: https://github.com/Gosha/tautulli-anidb-scrobbler/commit/65059835e565715308b4fc743120ba4fb56efe5c
+      buildImage = if hasKvm then
+        nixpkgs.dockerTools.buildImage
+      else
+        (nixpkgs.callPackage (nixpkgs.path + "/pkgs/build-support/docker") {
+          vmTools = overrideSet
+              (old: {
+                # delete the requirement on the kvm feature
+                runInLinuxVM = drv: nixpkgs.lib.overrideDerivation (old.runInLinuxVM drv) (_: {
+                  requiredSystemFeatures = [ ];
+                });
+              })
+              (nixpkgs.callPackage (nixpkgs.path + "/pkgs/build-support/vm") {
+                pkgs = nixpkgs // { qemu_kvm = nixpkgs.callPackage ./nix/wrapped-qemu.nix { }; };
+              });
+        }).buildImage;
   in {
     inherit server;
 
@@ -12,6 +31,7 @@
       contents = [ server ];
       runAsRoot = ''
         #!${nixpkgs.runtimeShell}
+        echo runAsRoot::
         mkdir -p /data
         cp -r ${server.out}/share/* /data
       '';

--- a/release.nix
+++ b/release.nix
@@ -21,14 +21,14 @@
               });
         }).buildImage;
   in {
-    inherit server;
+    inherit server nixpkgs;
 
     docker = buildImage {
       name = "Carnap";
       tag = "latest";
 
       # no base image, make a minimized image
-      contents = [ (nixpkgs.haskell.lib.justStaticExecutables server) ];
+      contents = [ server ];
       runAsRoot = ''
         #!${nixpkgs.runtimeShell}
         echo runAsRoot::

--- a/server.nix
+++ b/server.nix
@@ -4,6 +4,7 @@
     inherit (super.haskell.lib)
       overrideCabal
       dontCheck
+      disableSharedExecutables
       doJailbreak
       justStaticExecutables
       withGitignore;
@@ -69,6 +70,7 @@
                 enableExecutableProfiling = profiling;
                 enableLibraryProfiling = profiling;
                 buildDepends = [ book ];
+                executableSystemDepends = [ self.diagrams-builder ];
 
                 isExecutable = true;
                 # Carnap-Server has no tests/they are broken
@@ -82,11 +84,25 @@
                 # reduce closure size by deleting references to the pandoc
                 # binary. pandoc depends transitively on all installed haskell
                 # packages.  Bad for docker image size (4GB+).
-                disallowedReferences = [ newpkgs.pandoc ];
+                disallowedReferences = [
+                  newpkgs.warp
+                  newpkgs.yesod-core
+                  newpkgs.pandoc
+                  newpkgs.pandoc-types
+                ];
                 postInstall = ''
-                  echo 'deleting reference to pandoc'
+                  echo 'deleting reference to stuff with bins'
+                  remove-references-to \
+                    -t ${newpkgs.warp} \
+                    $out/bin/Carnap-Server
+                  remove-references-to \
+                    -t ${newpkgs.yesod-core} \
+                    $out/bin/Carnap-Server
                   remove-references-to \
                     -t ${newpkgs.pandoc} \
+                    $out/bin/Carnap-Server
+                  remove-references-to \
+                    -t ${newpkgs.pandoc-types} \
                     $out/bin/Carnap-Server
                 '';
               })));

--- a/server.nix
+++ b/server.nix
@@ -1,9 +1,12 @@
 { ghcjsVer, ghcVer, withHoogle ? true }:
   self: super:
-  let overrideCabal = super.haskell.lib.overrideCabal;
-      dontCheck = super.haskell.lib.dontCheck;
-      doJailbreak = super.haskell.lib.doJailbreak;
-      client-ghcjs = self.haskell.packages.${ghcjsVer}.Carnap-GHCJS;
+  let
+    inherit (super.haskell.lib)
+      overrideCabal
+      dontCheck
+      doJailbreak
+      withGitignore;
+    client-ghcjs = self.haskell.packages.${ghcjsVer}.Carnap-GHCJS;
   in {
     haskell = super.haskell // {
       packages = super.haskell.packages // {
@@ -33,14 +36,18 @@
             # ghcjs-dom = oldpkgs.callPackage ./nix/ghcjs-dom.nix { };
 
             # dontCheck: https://github.com/gleachkr/Carnap/issues/123
-            Carnap        = dontCheck (oldpkgs.callPackage ./Carnap/Carnap.nix { });
-            Carnap-Client = oldpkgs.callPackage ./Carnap-Client/Carnap-Client.nix { };
+            Carnap        = withGitignore
+                (dontCheck (oldpkgs.callPackage ./Carnap/Carnap.nix { }));
+            Carnap-Client = withGitignore
+                (oldpkgs.callPackage ./Carnap-Client/Carnap-Client.nix { });
+
             # for client development with ghc
-            # Carnap-GHCJS  = oldpkgs.callPackage ./Carnap-GHCJS/Carnap-GHCJS.nix { };
-            Carnap-Server = overrideCabal
+            # Carnap-GHCJS  = withGitignore
+            #    (oldpkgs.callPackage ./Carnap-GHCJS/Carnap-GHCJS.nix { });
+
+            Carnap-Server = withGitignore (overrideCabal
               (oldpkgs.callPackage ./Carnap-Server/Carnap-Server.nix { })
               (old: let book = ./Carnap-Book; in {
-                src = gitignoreSource ./Carnap-Server;
                 preConfigure = ''
                   mkdir -p $out/share
                   echo ":: Installing ${book} in $out/share/Carnap-Book"
@@ -66,7 +73,7 @@
                 # remove once updated past ghc865
                 # https://github.com/haskell/haddock/issues/979
                 doHaddock = false;
-              });
+              }));
           };
         };
       };

--- a/server.nix
+++ b/server.nix
@@ -38,22 +38,35 @@
             # for client development with ghc
             # Carnap-GHCJS  = oldpkgs.callPackage ./Carnap-GHCJS/Carnap-GHCJS.nix { };
             Carnap-Server = overrideCabal
-                              (oldpkgs.callPackage ./Carnap-Server/Carnap-Server.nix { })
-                              (old: {
-                                preConfigure = ''
-                                  echo "symlinking js in $(pwd)"
-                                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/all.js static/ghcjs/allactions/
-                                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/out.js static/ghcjs/allactions/
-                                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/lib.js static/ghcjs/allactions/
-                                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/runmain.js static/ghcjs/allactions/
-                                  '';
-                                extraLibraries = [ client-ghcjs ];
-                                # Carnap-Server has no tests/they are broken
-                                doCheck = false;
-                                # remove once updated past ghc865
-                                # https://github.com/haskell/haddock/issues/979
-                                doHaddock = false;
-                              });
+              (oldpkgs.callPackage ./Carnap-Server/Carnap-Server.nix { })
+              (old: let book = ./Carnap-Book; in {
+                src = gitignoreSource ./Carnap-Server;
+                preConfigure = ''
+                  mkdir -p $out/share
+                  echo ":: Installing ${book} in $out/share/Carnap-Book"
+                  cp -r ${book} $out/share/Carnap-Book
+                  echo ":: Copying static files"
+                  cp -r static $out/share/static
+
+                  echo ":: Symlinking js in $(pwd)"
+                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/all.js $out/share/static/ghcjs/allactions/
+                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/out.js $out/share/static/ghcjs/allactions/
+                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/lib.js $out/share/static/ghcjs/allactions/
+                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/runmain.js $out/share/static/ghcjs/allactions/
+                  echo ":: Adding a universal settings file"
+                  cp config/settings-example.yml config/settings.yml
+                  sed -i "s#/var/lib/carnap/book/#$out/share/Carnap-Book/#" config/settings.yml
+                  sed -i "s#_env:STATIC_DIR:static#_env:STATIC_DIR:$out/share/static#" config/settings.yml
+                  cat config/settings.yml
+                  '';
+                extraLibraries = [ client-ghcjs ];
+                buildDepends = [ book ];
+                # Carnap-Server has no tests/they are broken
+                doCheck = false;
+                # remove once updated past ghc865
+                # https://github.com/haskell/haddock/issues/979
+                doHaddock = false;
+              });
           };
         };
       };

--- a/server.nix
+++ b/server.nix
@@ -1,4 +1,4 @@
-{ ghcjsVer, ghcVer, withHoogle ? true }:
+{ ghcjsVer, ghcVer, withHoogle ? true, profiling ? false }:
   self: super:
   let
     inherit (super.haskell.lib)
@@ -67,6 +67,8 @@
                   cat config/settings.yml
                   '';
                 extraLibraries = [ client-ghcjs ];
+                enableExecutableProfiling = profiling;
+                enableLibraryProfiling = profiling;
                 buildDepends = [ book ];
                 # Carnap-Server has no tests/they are broken
                 doCheck = false;

--- a/server.nix
+++ b/server.nix
@@ -53,16 +53,17 @@
                 preConfigure = ''
                   mkdir -p $out/share
                   echo ":: Copying Carnap-Server data"
-                  cp -r {config,static} $out/share
                   cp -r ${book} $out/share/book
 
-                  echo ":: Symlinking js in $(pwd)"
-                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/all.js static/ghcjs/allactions/
-                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/out.js static/ghcjs/allactions/
-                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/lib.js static/ghcjs/allactions/
-                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/runmain.js static/ghcjs/allactions/
+                  echo ":: Copying js in $(pwd)"
+                  find static/ghcjs/allactions/ -type l -delete
+                  cp ${client-ghcjs.out}/bin/AllActions.jsexe/all.js static/ghcjs/allactions/
+                  cp ${client-ghcjs.out}/bin/AllActions.jsexe/out.js static/ghcjs/allactions/
+                  cp ${client-ghcjs.out}/bin/AllActions.jsexe/lib.js static/ghcjs/allactions/
+                  cp ${client-ghcjs.out}/bin/AllActions.jsexe/runmain.js static/ghcjs/allactions/
                   echo ":: Adding a universal settings file"
                   cp config/settings-example.yml config/settings.yml
+                  cp -r {config,static} $out/share
                   cat config/settings.yml
                   '';
 
@@ -84,25 +85,33 @@
                 # reduce closure size by deleting references to the pandoc
                 # binary. pandoc depends transitively on all installed haskell
                 # packages.  Bad for docker image size (4GB+).
-                disallowedReferences = [
-                  newpkgs.warp
-                  newpkgs.yesod-core
-                  newpkgs.pandoc
-                  newpkgs.pandoc-types
+                disallowedReferences = with newpkgs; [
+                  warp
+                  yesod-core
+                  pandoc
+                  pandoc-types
+                  HTTP
+                  tzdata
                 ];
-                postInstall = ''
+                postInstall = with newpkgs; ''
                   echo 'deleting reference to stuff with bins'
                   remove-references-to \
-                    -t ${newpkgs.warp} \
+                    -t ${warp} \
                     $out/bin/Carnap-Server
                   remove-references-to \
-                    -t ${newpkgs.yesod-core} \
+                    -t ${yesod-core} \
                     $out/bin/Carnap-Server
                   remove-references-to \
-                    -t ${newpkgs.pandoc} \
+                    -t ${pandoc} \
                     $out/bin/Carnap-Server
                   remove-references-to \
-                    -t ${newpkgs.pandoc-types} \
+                    -t ${pandoc-types} \
+                    $out/bin/Carnap-Server
+                  remove-references-to \
+                    -t ${HTTP} \
+                    $out/bin/Carnap-Server
+                  remove-references-to \
+                    -t ${tzdata} \
                     $out/bin/Carnap-Server
                 '';
               })));

--- a/server.nix
+++ b/server.nix
@@ -50,20 +50,17 @@
               (old: let book = ./Carnap-Book; in {
                 preConfigure = ''
                   mkdir -p $out/share
-                  echo ":: Installing ${book} in $out/share/Carnap-Book"
-                  cp -r ${book} $out/share/Carnap-Book
-                  echo ":: Copying static files"
-                  cp -r static $out/share/static
+                  echo ":: Copying Carnap-Server data"
+                  cp -r {config,static} $out/share
+                  cp -r ${book} $out/share/book
 
                   echo ":: Symlinking js in $(pwd)"
-                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/all.js $out/share/static/ghcjs/allactions/
-                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/out.js $out/share/static/ghcjs/allactions/
-                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/lib.js $out/share/static/ghcjs/allactions/
-                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/runmain.js $out/share/static/ghcjs/allactions/
+                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/all.js static/ghcjs/allactions/
+                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/out.js static/ghcjs/allactions/
+                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/lib.js static/ghcjs/allactions/
+                  ln -sf ${client-ghcjs.out}/bin/AllActions.jsexe/runmain.js static/ghcjs/allactions/
                   echo ":: Adding a universal settings file"
                   cp config/settings-example.yml config/settings.yml
-                  sed -i "s#/var/lib/carnap/book/#$out/share/Carnap-Book/#" config/settings.yml
-                  sed -i "s#_env:STATIC_DIR:static#_env:STATIC_DIR:$out/share/static#" config/settings.yml
                   cat config/settings.yml
                   '';
                 extraLibraries = [ client-ghcjs ];


### PR DESCRIPTION
Hi! I have some more code for review :)

## This change set:

* Adds GitHub Actions continuous integration for Carnap and its dependencies that pushes outputs to Cachix. It also builds a Docker image. If tests are written and `doCheck` reenabled in the Nix files, this would also run them on every push as well. It would be fairly easy to copy paste the Carnap-Server building part of this Action to make it run on pull requests as well, we'd just have to make sure we aren't accidentally pushing stuff from PRs to Cachix (may be resolved automatically by how GitHub Actions handles secrets, I am not certain). We also now have cached Mac binaries for all the dependencies by virtue of building on Mac as well, making it an order of magnitude faster to get started developing on that platform.

* Moves the signing key from `(current working directory)/config/client-session-key.aes` to `$DATAROOT/client-session-key.aes` in order to try to put all the writable stuff in one place (still a WIP situation though since the book folder and the static folder still need to be writable due to caching of things in both as far as I can tell).

* Makes the example config fully generic: everything can now be specified in environment variables, which means we can directly ship it as the default config for Docker.

* Adds gitignore support to our packages. This makes sure there's no gitignored stuff such as temporary files from Carnap-Server's static folder getting into Nix builds and causing pointless rebuilds.

* Substantially reduces the size of the Carnap-Server package and its dependencies (it is now 3GB, it used to be 11GB 🤯) by building it statically and removing references that were causing unused runtime dependencies.

* According readme changes.

## Stuff that needs to be arranged:

* Slight breakage of existing Carnap installations since they need the session key moved to their data directory.

* Cachix signing key needs to be added to the repository settings. If you want to make your own Cachix other than `jade-carnap`, feel free! (more on this on Matrix)