### PR TITLE
Make the super admin account configurable

### DIFF
--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -105,29 +105,33 @@ instance Yesod App where
          (CourseAssignmentR coursetitle _) -> studentAccessTo coursetitle
          AdminR -> admin
          _ -> return Authorized
-        where userOrInstructor ident =
-                do (Entity _ user) <- requireAuth
+        where superAdmin = appSuperAdmin . appSettings <$> getYesod
+              userOrInstructor ident =
+                do sa <- superAdmin
+                   (Entity _ user) <- requireAuth
                    let ident' = userIdent user
                    instructors <- instructorIdentList
                    return $ if ident' `elem` instructors
                                 --TODO Improve this to restrict to viewing your own students
                                || ident' == ident
-                               || ident' == "gleachkr@gmail.com"
+                               || ident' == sa
                             then Authorized
                             else Unauthorized "It appears you're not authorized to access this page"
               instructor ident =
-                 do (Entity _ user) <- requireAuth
+                 do sa <- superAdmin
+                    (Entity _ user) <- requireAuth
                     let ident' = userIdent user
                     instructors <- instructorIdentList
                     return $ if (ident' `elem` instructors
                                 && ident' == ident)
-                                || ident' == "gleachkr@gmail.com"
+                                || ident' == sa
                              then Authorized
                              else Unauthorized "It appears you're not authorized to access this page"
               studentAccessTo coursetitle =
                   --this is the route to assignments accessible by students
                   --for a given course and to instructors
-                  do (Entity uid user) <- requireAuth
+                  do sa <- superAdmin
+                     (Entity uid user) <- requireAuth
                      mcourse <- runDB $ getBy (UniqueCourse coursetitle)
                      (Entity cid course) <- case mcourse of Just c -> return c; _ -> setMessage "no course with that title" >> notFound
                      mudata <- runDB $ getBy (UniqueUserData uid)
@@ -138,24 +142,26 @@ instance Yesod App where
                                  || maybe False
                                           (\udata -> userDataEnrolledIn (entityVal udata) == Just cid)
                                           mudata
-                                 || userIdent user == "gleachkr@gmail.com"
+                                 || userIdent user == sa
                               then Authorized
                               else Unauthorized $ "It appears you're not authorized to access this page. For access, you need to enroll in the course \"" ++ coursetitle ++ "\". Is this the course you should be enrolled in?"
               coinstructorOrInstructor coursetitle =
                   --this is the route to the review area for a given course and
                   --assignment, and is for instructors only.
-                  do (Entity uid user) <- requireAuth
+                  do sa <- superAdmin
+                     (Entity uid user) <- requireAuth
                      mcourse <- runDB $ getBy (UniqueCourse coursetitle)
                      course <- case mcourse of Just c -> return c; _ -> setMessage "no course with that title" >> notFound
                      coInstructors <-  runDB $ map entityVal <$> selectList [CoInstructorCourse ==. entityKey course] []
                      instructors <- runDB $ selectList ([UserDataInstructorId ==. Just (courseInstructor $ entityVal course)]
                                                        ||. [UserDataInstructorId <-. map (Just . coInstructorIdent) coInstructors]) []
                      return $ if uid `elem` map (userDataUserId . entityVal) instructors
-                                 || userIdent user == "gleachkr@gmail.com"
+                                 || userIdent user == sa
                               then Authorized
                               else Unauthorized "It appears you're not authorized to access this page"
-              admin = do (Entity _ user) <- requireAuth
-                         return $ if userIdent user == "gleachkr@gmail.com"
+              admin = do sa <- superAdmin
+                         (Entity _ user) <- requireAuth
+                         return $ if userIdent user == sa
                                   then Authorized
                                   else Unauthorized "Only site administrators may access this page"
 

--- a/Carnap-Server/Handler/Admin.hs
+++ b/Carnap-Server/Handler/Admin.hs
@@ -144,9 +144,10 @@ unenrolledWidget students courses = do
             |]
 
 emailWidget :: [User] -> HandlerT App IO Widget
-emailWidget insts = do let emails = intercalate "," (map userIdent insts)
+emailWidget insts = do superAdmin <- appSuperAdmin . appSettings <$> getYesod
+                       let emails = intercalate "," (map userIdent insts)
                        return [whamlet|
-                          <a href="mailto:gleachkr@gmail.com?bcc=#{emails}">Email Instructors
+                          <a href="mailto:#{superAdmin}?bcc=#{emails}">Email Instructors
                        |]
 
 

--- a/Carnap-Server/Settings.hs
+++ b/Carnap-Server/Settings.hs
@@ -55,7 +55,8 @@ data AppSettings = AppSettings
     , appSkipCombining          :: Bool
     -- ^ Perform no stylesheet/script combining
 
-    -- Example app-specific configuration values.
+    , appSuperAdmin             :: Text
+    -- ^ Account @ident@ that will be assumed to have full access always
     , appCopyright              :: Text
     -- ^ Copyright text to appear in the footer of the page
     , appAnalytics              :: Maybe Text
@@ -92,7 +93,8 @@ instance FromJSON AppSettings where
         appMutableStatic          <- o .:? "mutable-static"   .!= appDevel
         appSkipCombining          <- o .:? "skip-combining"   .!= appDevel
 
-        appCopyright              <- o .: "copyright"
+        appSuperAdmin             <- o .:  "super-admin"
+        appCopyright              <- o .:  "copyright"
         appAnalytics              <- o .:? "analytics"
         appKey                    <- o .:? "google-api-key"   .!= ""
         appSecret                 <- o .:? "google-secret"    .!= ""

--- a/Carnap-Server/config/settings-example.yml
+++ b/Carnap-Server/config/settings-example.yml
@@ -31,6 +31,7 @@ database:
   database: "_env:PGDATABASE:carnapdb"
   poolsize: "_env:PGPOOLSIZE:10"
 
+super-admin: "_env:SUPERADMIN:gleachkr@gmail.com"
 copyright: Copyright 2015-2020 G. Leach-Krouse <gleachkr@ksu.edu> and J. Ehrlich
 
 #set to true if you want to run without a postgres installation


### PR DESCRIPTION
This is required for production Carnap deployments outside of Graham's
instance.

Breakage to existing sites: need to add the config option from the
example config. Otherwise, the default behaviour is the same as it was
before.