### PR TITLE
Attempt to fix persistent regression (#165)

### DIFF
--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -92,8 +92,8 @@ library
                  , classy-prelude-yesod          >=1.4 && <1.6
                  , bytestring                    >=0.9 && <0.11
                  , text                          >=0.11 && <2.0
-                 , persistent                    >=2.8 && <2.11
-                 , persistent-postgresql         >=2.8 && <2.11
+                 , persistent                    >=2.8 && <2.12
+                 , persistent-postgresql         >=2.8 && <2.12
                  , persistent-sqlite
                  , persistent-template           >= 2.5        && < 2.10
                  , template-haskell

--- a/default.nix
+++ b/default.nix
@@ -40,7 +40,7 @@ let
         (import ./nix/compose-haskell-overlays.nix {
           inherit ghcVer;
           overlays = [
-            (import ./server.nix { inherit profiling client; })
+            (import ./server.nix { inherit profiling client; inherit (sources) persistent; })
           ];
         })
       ];

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -34,5 +34,17 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/f8248ab6d9e69ea9c07950d73d48807ec595e923.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "persistent": {
+        "branch": "stockStrategyForShowRead",
+        "description": "Persistence interface for Haskell allowing multiple storage methods.",
+        "homepage": "",
+        "owner": "yesodweb",
+        "repo": "persistent",
+        "rev": "1cdadc10405e9e3b1e0e73e2c1d6ec84eed69a53",
+        "sha256": "0x50ix83k7v9r0g20g2dww295h864xrc5rrv5yk7pd3wvkz7mkv7",
+        "type": "tarball",
+        "url": "https://github.com/yesodweb/persistent/archive/1cdadc10405e9e3b1e0e73e2c1d6ec84eed69a53.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,16 @@ extra-deps:
     - th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869
     - haskell-src-exts-simple-1.22.0.0
     - haskell-src-exts-1.22.0
+    - git: https://github.com/yesodweb/persistent.git
+      commit: 1cdadc10405e9e3b1e0e73e2c1d6ec84eed69a53
+      subdirs:
+          - persistent
+          - persistent-sqlite
+          - persistent-postgresql
+          - persistent-template
+          - persistent-qq
+# :(
+allow-newer: true
 
 packages:
 - Carnap/


### PR DESCRIPTION
I have regrettably been unable to reproduce the bug on our side with the
broken version, but I have updated the build files to change to the
version with the fix anyway. Let me know if this works cleanly @gleachkr :)

The stack build is mostly untested because stack crashes halfway through
any build with an encoding error regardless of what locale overrides I
give it.

I added the dependency with this:

```
[nix-shell:~/dev/carnap]$ niv add yesodweb/persistent -b stockStrategyForShowRead
Adding package persistent
  Writing new sources file
Done: Adding package persistent
```

then did the hacking in this diff :)