### PR TITLE
Multiple admins

### DIFF
--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -117,60 +117,79 @@ instance Yesod App where
          (ReviewR coursetitle _) -> coinstructorOrInstructor coursetitle
          (CourseAssignmentR coursetitle _) -> studentAccessTo coursetitle
          AdminR -> admin
+         AdminPromoteR -> noAdmins
          _ -> return Authorized
         where userOrInstructor ident =
-                do (Entity _ user) <- requireAuth
+                do (Entity uid user) <- requireAuth
                    let ident' = userIdent user
                    instructors <- instructorIdentList
+                   userIsAdmin <- isAdmin uid
                    return $ if ident' `elem` instructors
                                 --TODO Improve this to restrict to viewing your own students
                                || ident' == ident
-                               || ident' == "gleachkr@gmail.com"
+                               || userIsAdmin
                             then Authorized
                             else Unauthorized "It appears you're not authorized to access this page"
               instructor ident =
-                 do (Entity _ user) <- requireAuth
+                 do (Entity uid user) <- requireAuth
                     let ident' = userIdent user
                     instructors <- instructorIdentList
+                    userIsAdmin <- isAdmin uid
                     return $ if (ident' `elem` instructors
                                 && ident' == ident)
-                                || ident' == "gleachkr@gmail.com"
+                                || userIsAdmin
                              then Authorized
                              else Unauthorized "It appears you're not authorized to access this page"
               studentAccessTo coursetitle =
                   --this is the route to assignments accessible by students
                   --for a given course and to instructors
-                  do (Entity uid user) <- requireAuth
+                  do (Entity uid _) <- requireAuth
                      mcourse <- runDB $ getBy (UniqueCourse coursetitle)
                      (Entity cid course) <- case mcourse of Just c -> return c; _ -> setMessage "no course with that title" >> notFound
                      mudata <- runDB $ getBy (UniqueUserData uid)
-                     coInstructors <-  runDB $ map entityVal <$> selectList [CoInstructorCourse ==. cid] []
+                     coInstructors <- runDB $ map entityVal <$> selectList [CoInstructorCourse ==. cid] []
                      instructors <- runDB $ selectList ([UserDataInstructorId ==. Just (courseInstructor course)]
                                                        ||. [UserDataInstructorId <-. map (Just . coInstructorIdent) coInstructors]) []
+                     userIsAdmin <- isAdmin uid
                      return $ if uid `elem` map (userDataUserId . entityVal) instructors
                                  || maybe False
                                           (\udata -> userDataEnrolledIn (entityVal udata) == Just cid)
                                           mudata
-                                 || userIdent user == "gleachkr@gmail.com"
+                                 || userIsAdmin
                               then Authorized
-                              else Unauthorized $ "It appears you're not authorized to access this page. For access, you need to enroll in the course \"" ++ coursetitle ++ "\". Is this the course you should be enrolled in?"
+                              else Unauthorized $ "It appears you're not authorized to access this page. " ++
+                                                  "For access, you need to enroll in the course \"" ++ coursetitle ++
+                                                  "\". Is this the course you should be enrolled in?"
               coinstructorOrInstructor coursetitle =
                   --this is the route to the review area for a given course and
                   --assignment, and is for instructors only.
-                  do (Entity uid user) <- requireAuth
+                  do (Entity uid _) <- requireAuth
                      mcourse <- runDB $ getBy (UniqueCourse coursetitle)
                      course <- case mcourse of Just c -> return c; _ -> setMessage "no course with that title" >> notFound
                      coInstructors <-  runDB $ map entityVal <$> selectList [CoInstructorCourse ==. entityKey course] []
                      instructors <- runDB $ selectList ([UserDataInstructorId ==. Just (courseInstructor $ entityVal course)]
                                                        ||. [UserDataInstructorId <-. map (Just . coInstructorIdent) coInstructors]) []
+                     userIsAdmin <- isAdmin uid
                      return $ if uid `elem` map (userDataUserId . entityVal) instructors
-                                 || userIdent user == "gleachkr@gmail.com"
+                                 || userIsAdmin
                               then Authorized
                               else Unauthorized "It appears you're not authorized to access this page"
-              admin = do (Entity _ user) <- requireAuth
-                         return $ if userIdent user == "gleachkr@gmail.com"
+              admin = do (Entity uid _) <- requireAuth
+                         userIsAdmin <- isAdmin uid
+                         return $ if userIsAdmin
                                   then Authorized
                                   else Unauthorized "Only site administrators may access this page"
+              -- only allow promoting the user if there are no other site administrators
+              -- otherwise they can add other admins on /master_admin
+              noAdmins =
+                  do _ <- requireAuth
+                     adminCount <- runDB $ count [UserDataIsAdmin ==. True]
+                     return $ if adminCount == 0
+                              then Authorized
+                              else Unauthorized "There are already site administrators on this site"
+              isAdmin uid = runDB $ do
+                  res <- getBy $ UniqueUserData uid
+                  return $ maybe False (userDataIsAdmin . entityVal) res
 
 
     -- This function creates static content files in the static folder

--- a/Carnap-Server/Handler/Admin.hs
+++ b/Carnap-Server/Handler/Admin.hs
@@ -139,7 +139,7 @@ postAdminPromoteR =
                         defaultLayout $ [whamlet|
                              Promoted, you can now <a href=@{AdminR}>manage the site
                         |]
-                    Nothing -> permissionDenied "user data missing??"
+                    Nothing -> permissionDenied "User data missing. This may mean you haven't assigned yourself a name yet."
             _ -> invalidArgs ["form failed"]
 
 upgradeToInstructor :: [User] -> Html -> MForm (HandlerFor App) (FormResult Text, WidgetFor App ())

--- a/Carnap-Server/Handler/Admin.hs
+++ b/Carnap-Server/Handler/Admin.hs
@@ -1,10 +1,11 @@
 {-#LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Handler.Admin where
 
 import Import
 import Handler.Instructor (dateDisplay)
 import Yesod.Form.Bootstrap3
-import Text.Blaze.Html (toMarkup)
+import Text.Blaze.Html (Markup, toMarkup)
 import qualified Data.Text as T
 import TH.RelativePaths (pathRelativeToCabalPackage)
 import Text.Julius (juliusFile)
@@ -89,7 +90,7 @@ getAdminR = do allUserData <- runDB $ selectList [] []
                         <form method=post enctype=#{enctypeUpgrade}>
                             ^{upgradeWidget}
                              <div.form-group>
-                                 <input.btn.btn-primary type=submit value="Upgrade">
+                                 <input.btn.btn-primary type=submit value="Upgrade Instructor">
                         <hr>
                         <h3> LTI 1.3 Configuration
                         <form method="post" enctype=#{enctypeLti}>
@@ -98,6 +99,48 @@ getAdminR = do allUserData <- runDB $ selectList [] []
                                 <input.btn.btn-primary type=submit value="Create new platform">
                         ^{ltiConfigsW}
                    |]
+
+getAdminPromoteR :: Handler Html
+getAdminPromoteR =
+    do aid <- maybeAuthId
+       aid' <- case aid of
+            Just a -> return $ a
+            Nothing -> permissionDenied "not logged in"
+       (promoteW, enctypePromote) <- generateFormPost $ promoteToAdmin (show aid')
+       defaultLayout $ do
+           [whamlet|
+            <div.container>
+                <h1> Become an administrator
+                <form method=post enctype=#{enctypePromote}>
+                    ^{promoteW}
+                    <div.form-group>
+                        <input.btn.btn-primary type=submit value="Promote me">
+           |]
+
+promoteToAdmin
+    :: String -> Markup -> MForm (HandlerFor App) (FormResult String, WidgetFor App ())
+promoteToAdmin ident = renderBootstrap3 BootstrapBasicForm $
+        areq userId "" (Just ident)
+    where userId = hiddenField
+
+postAdminPromoteR :: Handler Html
+postAdminPromoteR =
+    do aid <- maybeAuthId
+       aid' <- case aid of
+            Just a -> return $ a
+            Nothing -> permissionDenied "not logged in"
+       ((promoteResult, _), _) <- runFormPost $ promoteToAdmin (show aid')
+       case readMay <$> promoteResult of
+            FormSuccess (Just uid) -> do
+               userdata <- runDB $ getBy $ UniqueUserData uid
+               case userdata of
+                    Just (Entity key _) -> do
+                        runDB $ update key [UserDataIsAdmin =. True]
+                        defaultLayout $ [whamlet|
+                             Promoted, you can now <a href=@{AdminR}>manage the site
+                        |]
+                    Nothing -> permissionDenied "user data missing??"
+            _ -> invalidArgs ["form failed"]
 
 upgradeToInstructor :: [User] -> Html -> MForm (HandlerFor App) (FormResult Text, WidgetFor App ())
 upgradeToInstructor users = renderBootstrap3 BootstrapBasicForm $
@@ -121,7 +164,7 @@ unenrolledWidget students courses = do
                             <th> Ident
                             <th> Name
                         <tbody>
-                            $forall (User ident _, Entity _ (UserData fn ln _ _ _)) <- zip unenrolled unenrolledData
+                            $forall (User ident _, Entity _ (UserData {userDataFirstName = fn, userDataLastName = ln})) <- zip unenrolled unenrolledData
 
                                 <tr>
                                     <td>
@@ -129,7 +172,7 @@ unenrolledWidget students courses = do
                                     <td>
                                         #{ln}, #{fn}
                         <tbody>
-                            $forall (User ident _, Entity _ (UserData fn ln _ _ _)) <- zip expired expiredData
+                            $forall (User ident _, Entity _ (UserData {userDataFirstName = fn, userDataLastName = ln})) <- zip expired expiredData
 
                                 <tr>
                                     <td>
@@ -151,7 +194,7 @@ instructorWidget instructorPlus =
            let active = filter (\(c,_) -> courseEndDate (entityVal c) > time)
                inactive = filter (\(c,_) -> courseEndDate (entityVal c) < time)
            return [whamlet|
-                 $forall (instructor, Entity key (UserData fn ln _ _ _), courses) <- instructorPlus
+                 $forall (instructor, Entity key (UserData {userDataFirstName = fn, userDataLastName = ln}), courses) <- instructorPlus
                      <div.card style="margin-bottom:20px">
                          <div.card-header>
                              <a href=@{UserR (userIdent instructor)}>#{userIdent instructor}
@@ -163,7 +206,7 @@ instructorWidget instructorPlus =
                                      <thead>
                                          <th> Name
                                      <tbody>
-                                         $forall UserData sfn sln _ _ _ <- map entityVal enrollment
+                                         $forall UserData {userDataFirstName = sfn, userDataLastName = sln} <- map entityVal enrollment
                                              <tr>
                                                  <td>
                                                      #{sln}, #{sfn}

--- a/Carnap-Server/Handler/Chapter.hs
+++ b/Carnap-Server/Handler/Chapter.hs
@@ -64,7 +64,7 @@ content n cdir cdirp = do let matches = filter (\x -> (show n ++ ".pandoc") == d
                                        fileToHtml cdirp ""
                               (m:ms)  -> fileToHtml cdirp m
 
-fileToHtml path m = do md <- markdownFromFile (path ++ m)
+fileToHtml path m = do md <- markdownFromFile (path </> m)
                        case parseMarkdown yesodDefaultReaderOptions { readerExtensions = exts } md of
                            Right pd -> do pd' <- runFilters path pd
                                           return $ Right $ writePandocTrusted yesodDefaultWriterOptions { writerExtensions = exts } pd'

--- a/Carnap-Server/Model.hs
+++ b/Carnap-Server/Model.hs
@@ -21,6 +21,9 @@ import Carnap.GHCJS.SharedTypes(ProblemSource(..),ProblemType(..),ProblemData(..
 share [mkPersist sqlSettings, mkDeleteCascade sqlSettings, mkMigrate "migrateAll"]
     $(persistFileWith lowerCaseSettings =<< (pathRelativeToCabalPackage "config/models"))
 
+instructorIdentList
+    :: (PersistQueryRead (YesodPersistBackend site), YesodPersist site, BaseBackend (YesodPersistBackend site) ~ SqlBackend)
+    => HandlerFor site [Text]
 instructorIdentList = do instructorEntityList <- runDB $ selectList [UserDataInstructorId !=. Nothing] []
                          userEntityList <- runDB $ selectList [UserId <-. map (userDataUserId . entityVal) instructorEntityList ] []
                          return $ map (userIdent . entityVal) userEntityList

--- a/Carnap-Server/config/models
+++ b/Carnap-Server/config/models
@@ -9,6 +9,7 @@ UserData
     lastName Text
     enrolledIn CourseId Maybe
     instructorId InstructorMetadataId Maybe
+    isAdmin Bool default=false
     userId UserId
     UniqueUserData userId
 

--- a/Carnap-Server/config/routes
+++ b/Carnap-Server/config/routes
@@ -14,10 +14,11 @@
 /book                               BookR                    GET
 /book/#Int                          ChapterR                 GET
 /user                               UserDispatchR            GET
-/user/#Text                         UserR                    GET POST DELETE 
-/instructor/#Text                   InstructorR              GET PUT POST DELETE 
+/user/#Text                         UserR                    GET POST DELETE
+/instructor/#Text                   InstructorR              GET PUT POST DELETE
 /instructor/#Text/query             InstructorQueryR         POST
 /master_admin                       AdminR                   GET POST DELETE
+/admin_promote                      AdminPromoteR            GET POST
 /hash/#Text                         HashedR                  GET
 /assignments/#Text/#Text            CourseAssignmentR        GET POST
 /assignments/#Text/#Text/state      CourseAssignmentStateR   GET PUT

--- a/Carnap-Server/templates/instructor.hamlet
+++ b/Carnap-Server/templates/instructor.hamlet
@@ -88,7 +88,7 @@
                                                     #{dateDisplay from c}-#{dateDisplay till c}
                                                 $nothing
                                                     #{dateDisplay from c}-∞
-                                            $nothing 
+                                            $nothing
                                                 $maybe till <- assignmentMetadataVisibleTill a
                                                     ∞-#{dateDisplay till c}
                                                 $nothing
@@ -105,7 +105,7 @@
                                             <button.btn.btn-sm.btn-secondary alt="delete" title="delete this assignment" type="button" onclick="tryDeleteAssignment('#{jsonSerialize $ DeleteAssignment k}','#{documentFilename d}','#{courseTitle c}')">
                                                 <i.fa.fa-trash-o>
 
-                                            <button.btn.btn-sm.btn-secondary alt="edit" title="edit this assignment" type="button" onclick="modalEditAssignment('#{show k}','#{maybe "" (flip dateDisplay c) (assignmentMetadataDuedate a)}','#{maybe "" (flip dateDisplay c) (assignmentMetadataVisibleFrom a)}','#{maybe "" (flip dateDisplay c) (assignmentMetadataVisibleTill a)}','#{maybe "" sanatizeForJS (unpack <$> assignmentMetadataDescription a)}')">
+                                            <button.btn.btn-sm.btn-secondary alt="edit" title="edit this assignment" type="button" onclick="modalEditAssignment('#{show k}','#{maybe "" (flip dateDisplay c) (assignmentMetadataDuedate a)}','#{maybe "" (flip dateDisplay c) (assignmentMetadataVisibleFrom a)}','#{maybe "" (flip dateDisplay c) (assignmentMetadataVisibleTill a)}','#{maybe "" sanitizeForJS (unpack <$> assignmentMetadataDescription a)}')">
                                                 <i.fa.fa-cog>
                                             <a.btn.btn-sm.btn-secondary alt="review" title="review and assign partial credit" href=@{ReviewR (courseTitle c) (documentFilename d)}>
                                                 <i.fa.fa-pencil>
@@ -142,7 +142,7 @@
                                         <td>
                                             <button.btn.btn-sm.btn-secondary type="button" alt="delete" title="permanantly delete this document" onclick="tryDeleteDocument('#{jsonSerialize $ DeleteDocument (documentFilename a)}')">
                                                 <i.fa.fa-trash-o>
-                                            <button.btn.btn-sm.btn-secondary type="button" alt="edit" title="edit this document" onclick="modalEditDocument('#{show k}','#{maybe "" sanatizeForJS (unpack <$> documentDescription a)}','#{documentFilename a}', '#{tagString k}')">
+                                            <button.btn.btn-sm.btn-secondary type="button" alt="edit" title="edit this document" onclick="modalEditDocument('#{show k}','#{maybe "" sanitizeForJS (unpack <$> documentDescription a)}','#{documentFilename a}', '#{tagString k}')">
                                                 <i.fa.fa-cog>
                                             <button.btn.btn-sm.btn-secondary alt="download" title="download this document" type="button" onclick="window.open('@{DocumentDownloadR ident (documentFilename a)}')">
                                                 <i.fa.fa-cloud-download>
@@ -169,7 +169,7 @@
                                             <td>
                                                 <button.btn.btn-sm.btn-secondary type="button" alt="delete" title="permanantly delete this course" onclick="tryDeleteCourse('#{jsonSerialize $ DeleteCourse (courseTitle c)}')">
                                                     <i.fa.fa-trash-o>
-                                                <button.btn.btn-sm.btn-secondary type="button" alt="edit" title="edit this course" onclick="modalEditCourse('#{show cid}','#{maybe "" sanatizeForJS (unpack <$> courseDescription c)}','#{dateDisplay (courseStartDate c) c}','#{dateDisplay (courseEndDate c) c}',#{courseTotalPoints c})">
+                                                <button.btn.btn-sm.btn-secondary type="button" alt="edit" title="edit this course" onclick="modalEditCourse('#{show cid}','#{maybe "" sanitizeForJS (unpack <$> courseDescription c)}','#{dateDisplay (courseStartDate c) c}','#{dateDisplay (courseEndDate c) c}',#{courseTotalPoints c})">
                                                     <i.fa.fa-cog>
                                                 <button.btn.btn-sm.btn-secondary alt="download" title="download grades from this course" type="button" onclick=exportGrades('#{jsonSerialize cid}')">
                                                     <i.fa.fa-cloud-download>


### PR DESCRIPTION
This PR is based on #157 .

Sorry about the size of the diff, I compulsively fixed a pile of compiler warnings in the files I touched because of the addition of the column in `UserData`. These usages were changed to destructure it so this won't happen again if another field is added and reduce the possibility of mixing some fields up :)

Usage:

When the site is initially set up, you can log in then go to `/admin_promote` to become an administrator:
![image](https://user-images.githubusercontent.com/6652840/92288265-44e24600-eec1-11ea-811c-2cac028ca0df.png)

If there are already administrators, it is not permitted:
![image](https://user-images.githubusercontent.com/6652840/92288247-398f1a80-eec1-11ea-8663-86e4aeca505f.png)

I will add UI to manage administrators later as it comes up, in a future pull request (or just `update user_data set is_admin=true where user_id=...` because it is very infrequent).