### PR TITLE
"success" styling for multiple choice questions

### DIFF
--- a/Carnap-Server/static/css/exercises.css
+++ b/Carnap-Server/static/css/exercises.css
@@ -395,7 +395,8 @@
 [data-carnap-type="treedeductionchecker"].success > .input,
 [data-carnap-type="sequentchecker"].success > .input,
 [data-carnap-type="truthtable"].success > .input, 
-[data-carnap-type="countermodeler"].success > .input {
+[data-carnap-type="countermodeler"].success > .input,
+[data-carnap-type='qualitative'].success > .input {
     background: #b9f2b7;
 }
 
@@ -404,7 +405,8 @@
 [data-carnap-type="treedeductionchecker"].success > .input::after,
 [data-carnap-type="countermodeler"].success > .input::after,
 [data-carnap-type="sequentchecker"].success > .input::after,
-[data-carnap-type="truthtable"].success > .input::after {
+[data-carnap-type="truthtable"].success > .input::after,
+[data-carnap-type='qualitative'].success > .input::after {
     float: right;
     content:" ✓ ";
     font-size:16px;


### PR DESCRIPTION
Minor CSS tweak, to add the light green "success" styling and checkmark to multiple choice questions. Especially useful for multiple choice questions with the check button enabled but submissions disabled.