### PR TITLE
nix-build server doesn't use settings.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ Sessionx.vim
 *.sqlite3
 *.lock
 yesod-devel
-Carnap-Server/config/settings.yml
 dataroot
 Carnap-Book/cache
 Carnap-Server/static/tmp/

--- a/server.nix
+++ b/server.nix
@@ -81,7 +81,7 @@ newpkgs: oldpkgs: {
         cp ${client.out}/bin/AllActions.jsexe/lib.js static/ghcjs/allactions/
         cp ${client.out}/bin/AllActions.jsexe/runmain.js static/ghcjs/allactions/
         echo ":: Adding a universal settings file"
-        cp config/settings-example.yml config/settings.yml
+        cp -n config/settings-example.yml config/settings.yml
         cp -r {config,static} $out/share
         cat config/settings.yml
         '';


### PR DESCRIPTION
`server.nix` copies `Carnap-Server/config/settings-example.yml` to `settings.yml` before building. This change uses an existing `settings.yml` instead.
Because of the `gitignoreSource` at
https://github.com/Carnap/Carnap/blob/cf0aded1cb2c6d46cf0553748b6ec4b0bf1d99ae/server.nix#L70
`settings.yml` can't be gitignore'd.