### PR TITLE
Runtime configuration system

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,122 @@
+# See https://github.com/jaspervdj/stylish-haskell/blob/main/data/stylish-haskell.yaml
+# for reference.
+
+steps:
+  # - unicode_syntax:
+  #     add_language_pragma: true
+
+  # - module_header:
+  #     indent: 4
+  #     sort: true
+  #     separate_lists: true
+
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  # - records:
+  #     # How to format equals sign between type constructor and data constructor.
+  #     # Possible values:
+  #     # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+  #     equals: "indent 2"
+  #
+  #     # How to format first field of each record constructor.
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     first_field: "indent 2"
+  #
+  #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+  #     field_comment: 2
+  #
+  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+  #     deriving: 2
+  #
+  #     # How many spaces to insert before "via" clause counted from indentation of deriving clause
+  #     # Possible values:
+  #     # - "same_line" -- "via" part goes on the same line as "deriving" keyword.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of "deriving" keyword.
+  #     via: "indent 2"
+  #
+  #     # Sort typeclass names in the "deriving" list alphabetically.
+  #     sort_deriving: true
+  #
+  #     # Wheter or not to break enums onto several lines
+  #     #
+  #     # Default: false
+  #     break_enums: false
+  #
+  #     # Whether or not to break single constructor data types before `=` sign
+  #     #
+  #     # Default: true
+  #     break_single_constructors: true
+  #
+  #     # Whether or not to curry constraints on function.
+  #     #
+  #     # E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+  #     #
+  #     # Instead of @allValues :: (Enum a, Bounded a) => Proxy a -> [a]@
+  #     #
+  #     # Default: false
+  #     curried_context: false
+
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+      multi_way_if: true
+
+  - imports:
+      align: global
+      list_align: after_alias
+      pad_module_names: true
+      long_list_align: inline
+      empty_list_align: inherit
+      list_padding: 4
+      separate_lists: true
+      space_surround: false
+      ghc_lib_parser: false
+
+  - language_pragmas:
+      style: vertical
+      align: true
+      remove_redundant: true
+      language_prefix: LANGUAGE
+
+  # - tabs:
+  #     spaces: 8
+
+  - trailing_whitespace: {}
+
+  # - squash: {}
+
+columns: 80
+
+newline: native
+
+language_extensions:
+  - TemplateHaskell
+  - QuasiQuotes
+  - OverloadedStrings
+  - NoImplicitPrelude
+  - MultiParamTypeClasses
+  - TypeFamilies
+  - GADTs
+  - GeneralizedNewtypeDeriving
+  - FlexibleContexts
+  - FlexibleInstances
+  - EmptyDataDecls
+  - NoMonomorphismRestriction
+  - RankNTypes
+  - DeriveDataTypeable
+  - ViewPatterns
+  - TupleSections
+  - RecordWildCards
+
+cabal: true

--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -82,6 +82,7 @@ library
                 FlexibleContexts
                 FlexibleInstances
                 EmptyDataDecls
+                LambdaCase
                 NoMonomorphismRestriction
                 RankNTypes
                 DeriveDataTypeable

--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -23,6 +23,8 @@ library
                      Model
                      Settings
                      Settings.StaticFiles
+                     Settings.RuntimeDefs
+                     Settings.Runtime
                      Handler.Common
                      Handler.Home
                      Handler.Info

--- a/Carnap-Server/Filter/CounterModelers.hs
+++ b/Carnap-Server/Filter/CounterModelers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.CounterModelers (makeCounterModelers) where
 
 import Text.Pandoc

--- a/Carnap-Server/Filter/ProofCheckers.hs
+++ b/Carnap-Server/Filter/ProofCheckers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.ProofCheckers (makeProofChecker) where
 
 import Text.Pandoc

--- a/Carnap-Server/Filter/Qualitative.hs
+++ b/Carnap-Server/Filter/Qualitative.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.Qualitative (makeQualitativeProblems) where
 
 import Carnap.GHCJS.SharedFunctions (simpleHash, simpleCipher)

--- a/Carnap-Server/Filter/Sequent.hs
+++ b/Carnap-Server/Filter/Sequent.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.Sequent (makeSequent) where
 
 import Text.Pandoc

--- a/Carnap-Server/Filter/Sidenotes.hs
+++ b/Carnap-Server/Filter/Sidenotes.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.Sidenotes (makeSideNotes
 ) where
 

--- a/Carnap-Server/Filter/SynCheckers.hs
+++ b/Carnap-Server/Filter/SynCheckers.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.SynCheckers (makeSynCheckers) where
 
 import Text.Pandoc

--- a/Carnap-Server/Filter/Translate.hs
+++ b/Carnap-Server/Filter/Translate.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.Translate (makeTranslate) where
 
 import Carnap.GHCJS.SharedFunctions (simpleCipher)

--- a/Carnap-Server/Filter/TreeDeduction.hs
+++ b/Carnap-Server/Filter/TreeDeduction.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.TreeDeduction (makeTreeDeduction) where
 
 import Text.Pandoc

--- a/Carnap-Server/Filter/TruthTables.hs
+++ b/Carnap-Server/Filter/TruthTables.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.TruthTables (makeTruthTables) where
 
 import Text.Pandoc

--- a/Carnap-Server/Filter/Util.hs
+++ b/Carnap-Server/Filter/Util.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Filter.Util (splitIt, intoChunks, formatChunk, unlines',sanitizeHtml,
                     exerciseWrapper, contentOf, numof, toDataCarnap) where
 

--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -5,6 +5,7 @@ import           Database.Persist.Sql       (ConnectionPool, runSqlPool)
 import           Text.Hamlet                (hamletFile)
 import           TH.RelativePaths           (pathRelativeToCabalPackage)
 import           Yesod.Auth.Dummy           (authDummy)
+import           Yesod.Auth.Message         (AuthMessage (..))
 import           Yesod.Auth.OAuth2          (getUserResponseJSON)
 import           Yesod.Auth.OAuth2.Google
 import           Yesod.Core.Types           (Logger)
@@ -416,7 +417,7 @@ instance YesodAuth App where
                                 , "learning management system instead."]
 
               tryCreateUser :: Text -> (YesodDB App (AuthenticationResult App))
-              tryCreateUser un = maybe (ServerError noGoogleMessage) Authenticated
+              tryCreateUser un = maybe (UserError $ IdentifierNotFound noGoogleMessage) Authenticated
                                  <$> (runMaybeT $ do
                      guard =<< lift userCreationIsAllowed
                      lift . insert $ User

--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -410,9 +410,10 @@ instance YesodAuth App where
                           String email <- HM.lookup "email" o
                           Just creds0 { credsIdent = email }
 
-              noGoogleMessage = "Creating new Google accounts is disabled on \
-                               \ this Carnap instance. Log in via your \
-                               \ learning management system instead."
+            -- I want to make this multiline reasonably but ghci does not like it?!
+              noGoogleMessage = unwords ["Creating new Google accounts is disabled on "
+                                , "this Carnap instance. Log in via your "
+                                , "learning management system instead."]
 
               tryCreateUser :: Text -> (YesodDB App (AuthenticationResult App))
               tryCreateUser un = maybe (ServerError noGoogleMessage) Authenticated

--- a/Carnap-Server/Handler/Admin.hs
+++ b/Carnap-Server/Handler/Admin.hs
@@ -207,10 +207,12 @@ unenrolledWidget students courses = do
             |]
 
 emailWidget :: [User] -> HandlerFor App Widget
-emailWidget insts = do let emails = intercalate "," (map userIdent insts)
-                       return [whamlet|
-                          <a href="mailto:gleachkr@gmail.com?bcc=#{emails}">Email Instructors
-                       |]
+emailWidget insts = do
+    let emails = intercalate "," (map userIdent insts)
+    instanceAdmin <- runDB getInstanceAdminEmail
+    return [whamlet|
+       <a href="mailto:#{instanceAdmin}?bcc=#{emails}">Email Instructors
+    |]
 
 instructorWidget :: [(User,Entity UserData,[(Entity Course,[Entity UserData])])] -> HandlerFor App Widget
 instructorWidget instructorPlus =

--- a/Carnap-Server/Handler/Admin.hs
+++ b/Carnap-Server/Handler/Admin.hs
@@ -1,5 +1,4 @@
 {-#LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
 module Handler.Admin where
 
 import Import

--- a/Carnap-Server/Handler/Info.hs
+++ b/Carnap-Server/Handler/Info.hs
@@ -1,11 +1,14 @@
 module Handler.Info where
 
-import Import
-import Text.Shakespeare.Text
+import           Import
+import           Settings.Runtime
+import           Text.Shakespeare.Text
 --import Text.Hamlet
 
 getInfoR :: Handler Html
 getInfoR = do
+    instanceAdmin <- runDB getInstanceAdminEmail
+
     defaultLayout $ do
         addScript $ StaticR js_proof_js
         addScript $ StaticR js_popper_min_js
@@ -19,13 +22,14 @@ getInfoR = do
         addStylesheet $ StaticR css_proof_css
         addStylesheet $ StaticR css_exercises_css
         addStylesheet $ StaticR klement_proofs_css
+
         $(widgetFile "infopage")
         -- TODO : split out the stuff specifically relating to exercises
         addScript $ StaticR ghcjs_allactions_runmain_js
 
 -- TODO remove submit option on these.
 checker :: Int -> Text -> Text -> Text -> Text -> Text -> HtmlUrl url
-checker n thetype sys opts goal proof = 
+checker n thetype sys opts goal proof =
         [hamlet|
         <div class="exercise">
             <span>example #{show n}
@@ -60,10 +64,10 @@ pierceTheorem = [st|
           P     :3 R
           -P    :2 R
         Q       :4-6 -E
-     P->Q       :3-7 CI 
-     P          :8 1 CE 
+     P->Q       :3-7 CI
+     P          :8 1 CE
      -P         :2 R
-  P             :2-10 -E 
+  P             :2-10 -E
 ((P->Q)->P)->P  :1-11 CI |]
 
 lemmonTheorem = [st|

--- a/Carnap-Server/Import.hs
+++ b/Carnap-Server/Import.hs
@@ -4,4 +4,3 @@ module Import
 
 import Foundation                 as Import
 import Import.NoFoundation        as Import
-import Language.Haskell.TH.Syntax (Exp (ConE))

--- a/Carnap-Server/Import/NoFoundation.hs
+++ b/Carnap-Server/Import/NoFoundation.hs
@@ -25,5 +25,6 @@ type PersistentSite site =
      YesodAuthPersist site,
      AuthId site ~ Key User,
      AuthEntity site ~ User,
-     BaseBackend (YesodPersistBackend site) ~ SqlBackend)
+     BaseBackend (YesodPersistBackend site) ~ SqlBackend
+     )
 

--- a/Carnap-Server/Model.hs
+++ b/Carnap-Server/Model.hs
@@ -10,6 +10,7 @@ module Model where
 import ClassyPrelude.Yesod
 import Database.Persist.Quasi
 import Util.Data
+import Settings.RuntimeDefs
 import TH.RelativePaths (pathRelativeToCabalPackage)
 import Carnap.GHCJS.SharedTypes(ProblemSource(..),ProblemType(..),ProblemData(..), SomeRule(..))
 

--- a/Carnap-Server/Settings/Runtime.hs
+++ b/Carnap-Server/Settings/Runtime.hs
@@ -1,0 +1,36 @@
+module Settings.Runtime (
+    module Settings.RuntimeDefs,
+    getDisableGoogleReg,
+    setDisableGoogleReg
+) where
+
+import           Control.Monad.Trans.Maybe (MaybeT (..))
+import           Import.NoFoundation
+import           Settings.RuntimeDefs
+
+getSettingRaw :: PersistentSite site => RTSetType -> MaybeT (YesodDB site) ByteString
+getSettingRaw ty =
+    runtimeSettingValue . entityVal
+        <$> (MaybeT $ getBy (UniqueSetting ty))
+
+getSetting :: PersistentSite site => RTSetType -> MaybeT (YesodDB site) RTSetting
+getSetting ty = do
+    set <- getSettingRaw $ ty
+    MaybeT . return $ parseRtSetting ty set
+
+setSetting :: PersistentSite site => RTSetting -> YesodDB site ()
+setSetting set = do
+    let ser = serializeRtSetting set
+    _ <- upsert (RuntimeSetting (rtSettingType set) ser) [RuntimeSettingValue =. ser]
+    return ()
+
+withDefault :: Functor f => a -> MaybeT f a -> f a
+withDefault def comp = maybe def id <$> (runMaybeT comp)
+
+getDisableGoogleReg :: PersistentSite site => YesodDB site Bool
+getDisableGoogleReg = withDefault False $ do
+    DisableGoogleReg v <- getSetting TyDisableGoogleReg
+    return v
+
+setDisableGoogleReg :: PersistentSite site => Bool -> YesodDB site ()
+setDisableGoogleReg val = setSetting (DisableGoogleReg val)

--- a/Carnap-Server/Settings/Runtime.hs
+++ b/Carnap-Server/Settings/Runtime.hs
@@ -1,6 +1,7 @@
 module Settings.Runtime (
     module Settings.RuntimeDefs,
     getDisableGoogleReg,
+    getInstanceAdminEmail,
     setRtSetting,
     getRtSettings
 ) where
@@ -27,7 +28,10 @@ setRtSetting set = do
 
 getRtSettings :: PersistentSite site => YesodDB site [RTSetting]
 getRtSettings = do
-    sequence [DisableGoogleReg <$> getDisableGoogleReg]
+    sequence
+        [ DisableGoogleReg <$> getDisableGoogleReg
+        , InstanceAdminEmail <$> getInstanceAdminEmail
+        ]
 
 withDefault :: Functor f => a -> MaybeT f a -> f a
 withDefault def comp = maybe def id <$> (runMaybeT comp)
@@ -37,3 +41,7 @@ getDisableGoogleReg = withDefault False $ do
     DisableGoogleReg v <- getSetting TyDisableGoogleReg
     return v
 
+getInstanceAdminEmail :: PersistentSite site => YesodDB site Text
+getInstanceAdminEmail = withDefault "gleachkr@gmail.com" $ do
+    InstanceAdminEmail v <- getSetting TyInstanceAdminEmail
+    return v

--- a/Carnap-Server/Settings/Runtime.hs
+++ b/Carnap-Server/Settings/Runtime.hs
@@ -34,7 +34,7 @@ getRtSettings = do
         ]
 
 withDefault :: Functor f => a -> MaybeT f a -> f a
-withDefault def comp = maybe def id <$> (runMaybeT comp)
+withDefault def comp = fromMaybe def <$> (runMaybeT comp)
 
 getDisableGoogleReg :: PersistentSite site => YesodDB site Bool
 getDisableGoogleReg = withDefault False $ do

--- a/Carnap-Server/Settings/RuntimeDefs.hs
+++ b/Carnap-Server/Settings/RuntimeDefs.hs
@@ -7,22 +7,29 @@ import           Database.Persist.TH
 import qualified Data.Aeson as A
 
 data RTSetType =
-    TyDisableGoogleReg
+      TyDisableGoogleReg
     -- ^ disable new registrations of accounts with the Google login back end
+    | TyInstanceAdminEmail
+    -- ^ the email for the administrator of this Carnap instance
     deriving (Show, Read, Eq, Enum)
 
 data RTSetting =
-    DisableGoogleReg Bool
+      DisableGoogleReg Bool
+    | InstanceAdminEmail Text
     deriving (Show, Eq)
 
 rtSettingType :: RTSetting -> RTSetType
 rtSettingType (DisableGoogleReg _) = TyDisableGoogleReg
+rtSettingType (InstanceAdminEmail _) = TyInstanceAdminEmail
 
 parseRtSetting :: RTSetType -> ByteString -> Maybe RTSetting
 parseRtSetting TyDisableGoogleReg val =
     DisableGoogleReg <$> A.decodeStrict val
+parseRtSetting TyInstanceAdminEmail val =
+    InstanceAdminEmail <$> A.decodeStrict val
 
 serializeRtSetting :: RTSetting -> ByteString
 serializeRtSetting (DisableGoogleReg b) = toStrict . A.encode $ b
+serializeRtSetting (InstanceAdminEmail b) = toStrict . A.encode $ b
 
 derivePersistField "RTSetType"

--- a/Carnap-Server/Settings/RuntimeDefs.hs
+++ b/Carnap-Server/Settings/RuntimeDefs.hs
@@ -1,0 +1,28 @@
+-- Defines the runtime settings. You probably don't want to import this file,
+-- use Settings.Runtime instead which reexports everything from here.
+module Settings.RuntimeDefs where
+
+import           ClassyPrelude
+import           Database.Persist.TH
+import qualified Data.Aeson as A
+
+data RTSetType =
+    TyDisableGoogleReg
+    -- ^ disable new registrations of accounts with the Google login back end
+    deriving (Show, Read, Eq)
+
+data RTSetting =
+    DisableGoogleReg Bool
+    deriving (Show, Eq)
+
+rtSettingType :: RTSetting -> RTSetType
+rtSettingType (DisableGoogleReg _) = TyDisableGoogleReg
+
+parseRtSetting :: RTSetType -> ByteString -> Maybe RTSetting
+parseRtSetting TyDisableGoogleReg val =
+    DisableGoogleReg <$> A.decodeStrict val
+
+serializeRtSetting :: RTSetting -> ByteString
+serializeRtSetting (DisableGoogleReg b) = toStrict . A.encode $ b
+
+derivePersistField "RTSetType"

--- a/Carnap-Server/Settings/RuntimeDefs.hs
+++ b/Carnap-Server/Settings/RuntimeDefs.hs
@@ -9,7 +9,7 @@ import qualified Data.Aeson as A
 data RTSetType =
     TyDisableGoogleReg
     -- ^ disable new registrations of accounts with the Google login back end
-    deriving (Show, Read, Eq)
+    deriving (Show, Read, Eq, Enum)
 
 data RTSetting =
     DisableGoogleReg Bool

--- a/Carnap-Server/config/models
+++ b/Carnap-Server/config/models
@@ -73,6 +73,11 @@ CourseAutoreg
     UniqueAutoregTriple issuer deploymentId contextId
     deriving Show
 
+RuntimeSetting
+    which RTSetType
+    value ByteString
+    UniqueSetting which
+
 SyntaxCheckSubmission
     problem Text
     time UTCTime

--- a/Carnap-Server/templates/infopage.hamlet
+++ b/Carnap-Server/templates/infopage.hamlet
@@ -242,7 +242,7 @@
         <p>You can use Carnap to teach your own logic class!
 
         <p> All you need to do is <a href="@{AuthR LoginR}">create an account</a>,
-            \ and then <a href="mailto:gleachkr@ksu.edu">get in touch</a> to
+            \ and then <a href="mailto:#{instanceAdmin}">get in touch</a> to
             \ register as an instructor.
 
         <p> Once you're an instructor, you can use this site—the one you're on

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,19 @@
-.PHONY: help devel run shell-ghc build-ghc shell-ghcjs build-ghcjs tags build-production
+.PHONY: help devel run shell-ghc build-ghc shell-ghcjs build-ghcjs tags build-production hoogle
 TARGET := all
 
 help:
 	@echo "Usage: make [options] [target]"
 	@echo ""
 	@echo "Supported targets:"
-	@echo "    build-production 	Build and bundle everything needed to run the server in production"
-	@echo "    build-docker 		Build a production docker container"
-	@echo "    build-ghcjs 	 		Build a development client JavaScript with GHCJS"
-	@echo "    build-ghc 			Build a development server with GHC"
-	@echo "    shell-ghcjs		    Enter a nix shell for GHCJS client development"
-	@echo "    shell-ghc		    Enter a nix shell for GHC server development"
-	@echo "    devel				Build and run a development server locally, with data saved in this directory"
-	@echo "    tags				    Generate source code tags for development"
+	@echo "    build-production    Build and bundle everything needed to run the server in production"
+	@echo "    build-docker        Build a production docker container"
+	@echo "    build-ghcjs         Build a development client JavaScript with GHCJS"
+	@echo "    build-ghc           Build a development server with GHC"
+	@echo "    shell-ghcjs         Enter a nix shell for GHCJS client development"
+	@echo "    shell-ghc           Enter a nix shell for GHC server development"
+	@echo "    devel               Build and run a development server locally, with data saved in this directory"
+	@echo "    tags                Generate source code tags for development"
+	@echo "    hoogle              Starts a hoogle server with Carnap-Server's dependencies"
 	@echo ""
 	@echo "For more usage instructions, see README."
 
@@ -79,4 +80,7 @@ else
 endif
 
 tags:
-	hasktags -R .
+	nix-shell --run "hasktags -R ."
+
+hoogle:
+	nix-shell --run "hoogle server --local"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .PHONY: help devel run shell-ghc build-ghc shell-ghcjs build-ghcjs tags build-production hoogle
 TARGET := all
 
+CABALFLAGS := -f dev
+APPROOT := "http://localhost:3000"
+DATAROOT := "../dataroot"
+BOOKROOT := "../books/Carnap-Book/"
+
 help:
 	@echo "Usage: make [options] [target]"
 	@echo ""
@@ -47,9 +52,9 @@ else
 	cd Carnap-Server && \
 	cp -n config/settings-example.yml config/settings.yml && \
 	mkdir -p ../dataroot && \
-	APPROOT="http://localhost:3000" DATAROOT="../dataroot" \
-		BOOKROOT="../Carnap-Book/" \
-		cabal run -f dev Carnap-Server
+	APPROOT=$(APPROOT) DATAROOT=$(DATAROOT) \
+		BOOKROOT=$(BOOKROOT) \
+		cabal run $(CABALFLAGS) Carnap-Server $(CONFIGFILE)
 endif
 
 shell-ghc:


### PR DESCRIPTION
This patch set adds a system for configuring certain features of the Carnap server at runtime without having to change the config file.

Here is the new UI:

![image](https://user-images.githubusercontent.com/6652840/123738676-1bcce080-d85a-11eb-9369-b19b9f11a02b.png)

Google creation disabled error (this is slightly crappy because yesod-auth seems to have made it impossible to have completely custom messages so we just get the weird prefix...):

![image](https://user-images.githubusercontent.com/6652840/123743497-2db28180-d862-11eb-9cf4-a6f4098644a6.png)
