### PR TITLE
Fix remaining outdated links to freenode

### DIFF
--- a/Carnap-Server/templates/infopage.hamlet
+++ b/Carnap-Server/templates/infopage.hamlet
@@ -372,8 +372,8 @@
            \ an issue on Github. For general questions or discussion, you can
            \ also reach us on
            <a href="https://matrix.to/#/!AqFOGENiPssQgsjxfE:matrix.org?via=matrix.org">Matrix,
-           \ on IRC at
-           <a href="https://web.libera.chat/gamja/?channels=%23carnap">irc://irc.libera.chat/carnap,
+           \ which is bridged on IRC at
+           <a href="https://web.libera.chat/gamja/?channels=%23carnap">ircs://irc.libera.chat:6697/carnap,
            \ or over
            <a href="mailto:gleachkr@ksu.edu">email#
            \.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ repository, in case you'd like to contribute or suggest an edit.
 
 If you'd like to discuss development and administration of Carnap instances in
 real time, we have a chat room on
-[Matrix](https://matrix.to/#/!AqFOGENiPssQgsjxfE:matrix.org?via=matrix.org) or
-[freenode (#carnap)](irc://irc.freenode.net/carnap).
+[Matrix](https://matrix.to/#/!AqFOGENiPssQgsjxfE:matrix.org?via=matrix.org),
+bridged to [libera.chat in #carnap](ircs://irc.libera.chat:6697/carnap).
 
 There is also a mailing list, primarily focused on instructor support, on
 [Google Groups](https://groups.google.com/g/carnap-users).


### PR DESCRIPTION
There was another in the readme, and I clarified the wording on the info
page and updated it to a TLS link for good measure.