### PR TITLE
Rudolf integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ tags
 TAGS
 client-out
 server-out
+truth-tree-out
 result
 cabal.project.local
 .cabal-fake-client-out/

--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -54,6 +54,7 @@ library
                      Filter.ProofCheckers
                      Filter.Translate
                      Filter.TruthTables
+                     Filter.TruthTrees
                      Filter.CounterModelers
                      Filter.Qualitative
                      Filter.Util

--- a/Carnap-Server/Filter/TruthTrees.hs
+++ b/Carnap-Server/Filter/TruthTrees.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Filter.TruthTrees (makeTruthTrees) where
+
+import Text.Pandoc
+import Data.Text (Text)
+import qualified Data.Text as T
+import Util.Data
+import Filter.Util (numof, contentOf, intoChunks)
+import Prelude
+
+makeTruthTrees :: Block -> Block
+makeTruthTrees cb@(CodeBlock (_, classes, extra) contents)
+    | "TruthTree" `elem` classes = Div ("", [], []) $ map (pushExerciseParams classes extra) $ intoChunks contents
+    | otherwise = cb
+makeTruthTrees x = x
+
+pushExerciseParams :: [Text] -> [(Text, Text)] -> Text -> Block
+pushExerciseParams cls _extra chunk
+    | "Prop" `elem` cls = Div (problemElId, [], []) [
+            RawBlock "html" (T.concat
+                [ "\n<script>\n"
+                , "document.TruthTrees ||= [];\n"
+                , "document.TruthTrees.push(['" 
+                , problemElId
+                , "', '"
+                , escape . contentOf $ chunk
+                , "']);\n"
+                ,"</script>\n" ])
+        ]
+    | otherwise = RawBlock "html" "<div>No matching truth tree logic</div>"
+    where escape = T.pack . sanitizeForJS . T.unpack
+          problemElId = T.concat ["problem-", numof chunk]

--- a/Carnap-Server/Handler/Assignment.hs
+++ b/Carnap-Server/Handler/Assignment.hs
@@ -1,37 +1,28 @@
 module Handler.Assignment (postCourseAssignmentR, getCourseAssignmentR, getCourseAssignmentStateR, putCourseAssignmentStateR) where
 
-import Import
-import Util.Data
-import Util.Database
-import Util.Assignment
-import Yesod.Form.Bootstrap3
-import Text.Blaze.Html (toMarkup)
-import Text.Pandoc (lookupMeta)
-import System.Directory (doesFileExist,getDirectoryContents)
-import Data.Time
-import Data.Aeson.Types
-import Data.Time.Clock.POSIX
-import Text.Julius (juliusFile,rawJS)
-import TH.RelativePaths (pathRelativeToCabalPackage)
-import Filter.Randomize
-import Filter.SynCheckers
-import Filter.ProofCheckers
-import Filter.Translate
-import Filter.TruthTables
-import Filter.CounterModelers
-import Filter.Qualitative
-import Filter.Sequent
-import Filter.TreeDeduction
-import Filter.RenderFormulas
-import Util.Handler
+import           Data.Aeson.Types
+import           Data.Time
+import           Data.Time.Clock.POSIX
+import           Import
+import           Text.Blaze.Html              (Markup, toMarkup)
+import           Text.Julius                  (juliusFile, rawJS)
+import           Text.Pandoc                  (Block, lookupMeta)
+import           TH.RelativePaths             (pathRelativeToCabalPackage)
+import           Yesod.Form.Bootstrap3
+
+import           Filter.Randomize
+import           Util.Assignment
+import           Util.Data
+import           Util.Database
+import           Util.Handler
 
 getCourseAssignmentR :: Text -> Text -> Handler Html
 getCourseAssignmentR coursetitle filename = getAssignmentAndPathByCourse coursetitle filename
                                             >>= uncurry (returnAssignment coursetitle filename)
 
 putCourseAssignmentStateR :: Text -> Text -> Handler Value
-putCourseAssignmentStateR coursetitle filename = do
-        msg <- requireJsonBody :: Handler Value
+putCourseAssignmentStateR _coursetitle _filename = do
+        msg <- requireCheckJsonBody :: Handler Value
         uid <- maybeAuthId >>= maybe reject return
         let maid = parseMaybe (withObject "assignment key" (.: "assignmentKey")) msg :: Maybe Text
         aid <- maybe (sendStatusJSON badRequest400 ("Ill-formed assignment key" :: Text)) return (maid >>= readMay :: Maybe (Key AssignmentMetadata))
@@ -39,25 +30,25 @@ putCourseAssignmentStateR coursetitle filename = do
         returnJson msg
 
 getCourseAssignmentStateR :: Text -> Text -> Handler Value
-getCourseAssignmentStateR coursetitle filename = do
+getCourseAssignmentStateR _coursetitle _filename = do
         uid <- maybeAuthId >>= maybe reject return
         maid <- lookupGetParam "aid"
         aid <- maybe (sendStatusJSON badRequest400 ("Ill-formed assignment key" :: Text)) return (maid >>= readMay :: Maybe (Key AssignmentMetadata))
         mstate <- runDB $ getBy (UniqueAssignmentState uid aid)
         case mstate of
             Just (Entity _ state) -> returnJson (assignmentStateValue state)
-            Nothing -> returnJson (mempty :: Object)
+            Nothing               -> returnJson (mempty :: Object)
 
 postCourseAssignmentR :: Text -> Text -> Handler Html
 postCourseAssignmentR coursetitle filename = do
         Entity key val <- getAssignmentByCourse coursetitle filename
-        uid <- maybeAuthId >>= maybe reject return 
+        uid <- maybeAuthId >>= maybe reject return
         ((passrslt,_),_) <- runFormPost (identifyForm "enterPassword" $ enterPasswordForm)
         case passrslt of
             FormSuccess password ->
                 let insertToken = do currentTime <- liftIO getCurrentTime
                                      mtoken <- runDB $ insertUnique $ AssignmentAccessToken currentTime key uid
-                                     case mtoken of 
+                                     case mtoken of
                                             Nothing -> $logWarn "couldn't insert access token. Double POST?"
                                             _ -> return ()
                                      setMessage $ "Access Granted"
@@ -72,23 +63,29 @@ returnAssignment :: Text -> Text -> Entity AssignmentMetadata -> FilePath -> Han
 returnAssignment coursetitle filename (Entity key val) path = do
         uid <- maybeAuthId >>= maybe reject return
         Entity _ userdata <- maybeUserData >>= maybe reject return
-        (maccess,mtoken,mextension) <- runDB $ do 
+        (maccess,mtoken,mextension) <- runDB $ do
                maccess <- getBy $ UniqueAccommodation (assignmentMetadataCourse val) uid
                mtoken <- getBy $ UniqueAssignmentAccessToken uid key
-               mextension <- getBy $ UniqueExtension key uid 
+               mextension <- getBy $ UniqueExtension key uid
                return (maccess,mtoken,mextension)
         time <- liftIO getCurrentTime
         let accommodationFactor = maybe 1 (accommodationTimeFactor . entityVal) maccess
             accommodationMinutes = maybe 0 (accommodationTimeExtraMinutes . entityVal) maccess
+            testTime :: Int -> Int
             testTime min = floor ((fromIntegral min) * accommodationFactor) + accommodationMinutes
             instructorAccess = userDataInstructorId userdata /= Nothing --instructors who shouldn't access the course are already blocked by yesod-auth
             age (Entity _ tok) = floor (diffUTCTime time (assignmentAccessTokenCreatedAt tok))
+
+            creation :: Entity AssignmentAccessToken -> Integer
             creation (Entity _ tok) = round $ utcTimeToPOSIXSeconds (assignmentAccessTokenCreatedAt tok) * 1000 --milliseconds to match JS
+
             jsMaybe f v = maybe (rawJS ("null" :: Text)) (rawJS . f) v
+            toJsTime = show . toMS . round . utcTimeToPOSIXSeconds
+            toMS :: Integer -> Integer
             toMS x = x * 1000
         if visibleAt time val mextension || instructorAccess
             then do
-                ehtml <- liftIO $ fileToHtml (allFilters (hash (show uid ++ path))) path
+                ehtml <- liftIO $ fileToHtml (assignmentFilters (hash (show uid ++ path))) path
                 unless (visibleAt time val mextension) $ setMessage "Viewing as instructor. Assignment not currently visible to students."
                 case ehtml of
                     Left err -> defaultLayout $ minimalLayout (show err)
@@ -106,10 +103,10 @@ returnAssignment coursetitle filename (Entity key val) path = do
                              mcss <- retrievePandocVal (lookupMeta "css" meta)
                              mjs <- retrievePandocVal (lookupMeta "js" meta)
                              let source = "assignment:" ++ show key
-                                 theLayout = \widget -> case mbcss of 
-                                    Nothing -> defaultLayout $ do mapM addStylesheet [StaticR css_bootstrapextra_css] 
+                                 theLayout = \widget -> case mbcss of
+                                    Nothing -> defaultLayout $ do mapM addStylesheet [StaticR css_bootstrapextra_css]
                                                                   widget
-                                    Just bcss -> cleanLayout $ do mapM addStylesheetRemote bcss 
+                                    Just bcss -> cleanLayout $ do mapM addStylesheetRemote bcss
                                                                   widget
                              theLayout $ do
                                  toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/command.julius")
@@ -140,22 +137,19 @@ returnAssignment coursetitle filename (Entity key val) path = do
     where visibleAt t a mex = not (tooEarly t a) && not (tooLate t a mex)
           tooEarly t a | null (assignmentMetadataVisibleFrom a) = False
                        | otherwise = Just t < assignmentMetadataVisibleFrom a
-          tooLate t a _ | null (assignmentMetadataVisibleTill a) = False
+          tooLate _ a _ | null (assignmentMetadataVisibleTill a) = False
           tooLate t a Nothing = assignmentMetadataVisibleTill a < Just t
           tooLate t a (Just (Entity _ ex)) = (extensionUntil ex < t) && (assignmentMetadataVisibleTill a < Just t)
 
-allFilters salt = randomizeProblems salt
-                  . makeTreeDeduction
-                  . makeSequent
-                  . makeSynCheckers
-                  . makeProofChecker
-                  . makeTranslate
-                  . makeTruthTables
-                  . makeCounterModelers
-                  . makeQualitativeProblems
-                  . renderFormulas
+assignmentFilters :: Int -> Block -> Block
+assignmentFilters salt = randomizeProblems salt . allFilters
 
+enterPasswordForm
+    :: (MonadHandler m, RenderMessage (HandlerSite m) FormMessage)
+    => Markup
+    -> MForm m (FormResult Text, WidgetFor (HandlerSite m) ())
 enterPasswordForm = renderBootstrap3 BootstrapBasicForm $ id
             <$> areq textField (bfs ("Access Key" :: Text)) Nothing
 
+reject :: (MonadHandler m, RedirectUrl (HandlerSite m) (Route App)) => m b
 reject = setMessage "you need to be logged in and fully registered to access assignments" >> redirect HomeR

--- a/Carnap-Server/Handler/Assignment.hs
+++ b/Carnap-Server/Handler/Assignment.hs
@@ -120,18 +120,12 @@ returnAssignment coursetitle filename (Entity key val) path = do
                                                                              var token_time = #{rawJS $ show $ creation tok};
                                                                            |]
                                      (_,_) -> return ()
-                                 addScript $ StaticR js_proof_js
-                                 addScript $ StaticR js_popper_min_js
-                                 addScript $ StaticR ghcjs_rts_js
-                                 addScript $ StaticR ghcjs_allactions_lib_js
-                                 addScript $ StaticR ghcjs_allactions_out_js
-                                 addStylesheet $ StaticR css_proof_css
-                                 addStylesheet $ StaticR css_tree_css
-                                 addStylesheet $ StaticR css_exercises_css
+
+                                 addDocScripts
+
                                  maybe (pure [()]) (mapM addStylesheetRemote) mcss
                                  $(widgetFile "document")
                                  toWidgetBody [julius|CarnapServerAPI.getAssignmentState();|]
-                                 addScript $ StaticR ghcjs_allactions_runmain_js
                                  maybe (pure [()]) (mapM addScriptRemote) mjs >> return ()
             else defaultLayout $ minimalLayout ("Assignment not currently set as visible by instructor" :: Text)
     where visibleAt t a mex = not (tooEarly t a) && not (tooLate t a mex)

--- a/Carnap-Server/Handler/Chapter.hs
+++ b/Carnap-Server/Handler/Chapter.hs
@@ -1,25 +1,28 @@
 module Handler.Chapter where
 
-import Import
-import Yesod.Markdown
-import Data.Char (isDigit)
-import Filter.Sidenotes
-import Filter.SynCheckers
-import Filter.ProofCheckers
-import Filter.Translate
-import Filter.TruthTables
-import Filter.CounterModelers
-import Filter.Qualitative
-import Text.Pandoc
-import Text.Pandoc.Walk (walkM, walk)
-import System.Directory (getDirectoryContents)
-import Text.Julius (juliusFile)
-import Text.Hamlet (hamletFile)
-import TH.RelativePaths (pathRelativeToCabalPackage)
-import qualified Data.CaseInsensitive as CI
-import qualified Data.Text.Encoding as TE
-import Control.Monad.State (evalState)
-import Util.Database
+import           Import
+
+import           Control.Monad.State    (evalState)
+import qualified Data.CaseInsensitive   as CI
+import           Data.Char              (isDigit)
+import qualified Data.Text.Encoding     as TE
+import           System.Directory       (getDirectoryContents)
+import           Text.Hamlet            (hamletFile)
+import           Text.Julius            (juliusFile)
+import           Text.Pandoc
+import           Text.Pandoc.Walk       (walk, walkM)
+import           TH.RelativePaths       (pathRelativeToCabalPackage)
+import           Yesod.Markdown
+
+import           Filter.CounterModelers
+import           Filter.ProofCheckers
+import           Filter.Qualitative
+import           Filter.Sidenotes
+import           Filter.SynCheckers
+import           Filter.Translate
+import           Filter.TruthTables
+import           Util.Database
+import           Util.Handler           (addDocScripts)
 
 -- XXX Fair amount of code-duplication between this and Handler/Book.hs. Perhaps merge those modules.
 

--- a/Carnap-Server/Handler/Chapter.hs
+++ b/Carnap-Server/Handler/Chapter.hs
@@ -105,17 +105,9 @@ chapterLayout widget = do
             toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/command.julius")
             toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/status-warning.julius")
             toWidgetHead [julius|var submission_source="book";|]
-            addScript $ StaticR js_popper_min_js
-            addScript $ StaticR ghcjs_rts_js
-            addScript $ StaticR ghcjs_allactions_lib_js
-            addScript $ StaticR ghcjs_allactions_out_js
-            addStylesheet $ StaticR css_tree_css
             addStylesheet $ StaticR css_tufte_css
             addStylesheet $ StaticR css_tuftextra_css
-            addStylesheet $ StaticR css_exercises_css
-            addStylesheet $ StaticR truth_tree_lib_css
             $(widgetFile "default-layout")
-            addScript $ StaticR ghcjs_allactions_runmain_js
-            toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/createTrees.julius")
+            addDocScripts
 
         withUrlRenderer $(hamletFile =<< pathRelativeToCabalPackage "templates/default-layout-wrapper.hamlet")

--- a/Carnap-Server/Handler/Document.hs
+++ b/Carnap-Server/Handler/Document.hs
@@ -114,18 +114,10 @@ getDocumentR ident title = do (Entity key doc, path, creatorid) <- retrieveDoc i
                                                                      widget
                       theLayout $ do
                           toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/command.julius")
-                          addScript $ StaticR js_proof_js
-                          addScript $ StaticR js_popper_min_js
-                          addScript $ StaticR ghcjs_rts_js
-                          addScript $ StaticR ghcjs_allactions_lib_js
-                          addScript $ StaticR ghcjs_allactions_out_js
+                          addDocScripts
                           maybe (pure [()]) (mapM addScriptRemote) mjs
-                          addStylesheet $ StaticR css_tree_css
-                          addStylesheet $ StaticR css_proof_css
-                          addStylesheet $ StaticR css_exercises_css
                           maybe (pure [()]) (mapM addStylesheetRemote) mcss
                           $(widgetFile "document")
-                          addScript $ StaticR ghcjs_allactions_runmain_js
 
 getDocumentDownloadR :: Text -> Text -> Handler TypedContent
 getDocumentDownloadR ident title = do (Entity key doc, path, creatoruid) <- retrieveDoc ident title

--- a/Carnap-Server/Handler/Document.hs
+++ b/Carnap-Server/Handler/Document.hs
@@ -11,15 +11,6 @@ import System.FilePath
 import Util.Data
 import Util.Database
 import Util.Handler
-import Filter.SynCheckers
-import Filter.ProofCheckers
-import Filter.Translate
-import Filter.TruthTables
-import Filter.CounterModelers
-import Filter.Qualitative
-import Filter.Sequent
-import Filter.TreeDeduction
-import Filter.RenderFormulas
 
 getDocumentsR :: Handler Html
 getDocumentsR =  runDB (selectList [] []) >>= documentsList "Index of All Documents"
@@ -156,13 +147,3 @@ retrieveDoc ident title = do userdir <- getUserDir ident
 
 getUserDir ident = do master <- getYesod
                       return $ (appDataRoot $ appSettings master) </> "documents" </> unpack ident
-
-allFilters = makeTreeDeduction
-             . makeSequent
-             . makeSynCheckers
-             . makeProofChecker
-             . makeTranslate
-             . makeTruthTables
-             . makeCounterModelers
-             . makeQualitativeProblems
-             . renderFormulas

--- a/Carnap-Server/Handler/Info.hs
+++ b/Carnap-Server/Handler/Info.hs
@@ -3,29 +3,18 @@ module Handler.Info where
 import           Import
 import           Settings.Runtime
 import           Text.Shakespeare.Text
---import Text.Hamlet
+import           Util.Handler          (addDocScripts)
 
 getInfoR :: Handler Html
 getInfoR = do
     instanceAdmin <- runDB getInstanceAdminEmail
 
     defaultLayout $ do
-        addScript $ StaticR js_proof_js
-        addScript $ StaticR js_popper_min_js
-        addScript $ StaticR ghcjs_rts_js
-        addScript $ StaticR ghcjs_allactions_lib_js
-        addScript $ StaticR ghcjs_allactions_out_js
-        addScript $ StaticR klement_proofs_js
-        addScript $ StaticR klement_syntax_js
+        addDocScripts
         setTitle "Carnap - About"
-        addStylesheet $ StaticR css_tree_css
-        addStylesheet $ StaticR css_proof_css
-        addStylesheet $ StaticR css_exercises_css
-        addStylesheet $ StaticR klement_proofs_css
 
         $(widgetFile "infopage")
         -- TODO : split out the stuff specifically relating to exercises
-        addScript $ StaticR ghcjs_allactions_runmain_js
 
 -- TODO remove submit option on these.
 checker :: Int -> Text -> Text -> Text -> Text -> Text -> HtmlUrl url

--- a/Carnap-Server/Handler/Instructor.hs
+++ b/Carnap-Server/Handler/Instructor.hs
@@ -1176,15 +1176,6 @@ dateDisplay inUtc course = case tzByName $ courseTimeZone course of
 maybeDo :: Monad m => Maybe t -> (t -> m ()) -> m ()
 maybeDo mv f = case mv of Just v -> f v; _ -> return ()
 
-sanitizeForJS :: String -> String
-sanitizeForJS ('\n':xs) = '\\' : 'n' : sanitizeForJS xs
-sanitizeForJS ('\\':xs) = '\\' : '\\' : sanitizeForJS xs
-sanitizeForJS ('\'':xs) = '\\' : '\'' : sanitizeForJS xs
-sanitizeForJS ('"':xs)  = '\\' : '"' : sanitizeForJS xs
-sanitizeForJS ('\r':xs) = sanitizeForJS xs
-sanitizeForJS (x:xs) = x : sanitizeForJS xs
-sanitizeForJS [] = []
-
 -- TODO compare directory contents with database results
 listAssignmentMetadata
     :: Entity Course

--- a/Carnap-Server/Handler/Review.hs
+++ b/Carnap-Server/Handler/Review.hs
@@ -1,26 +1,32 @@
-{-#LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Handler.Review (getReviewR, putReviewR, deleteReviewR) where
 
-import Import
-import Util.Data
-import Util.Assignment
-import Data.Map as M (fromList)
-import Data.Tree
-import Data.List (nub)
-import Filter.Util (sanitizeHtml)
-import Text.Read (readMaybe)
-import Yesod.Form.Bootstrap3
-import Carnap.Languages.PurePropositional.Syntax
-import Carnap.Languages.PureFirstOrder.Syntax
-import Carnap.Languages.PurePropositional.Logic (ofPropSys)
-import Carnap.Languages.PureFirstOrder.Logic (ofFOLSys)
-import Carnap.Languages.SetTheory.Logic (ofSetTheorySys)
-import Carnap.Languages.PureSecondOrder.Logic (ofSecondOrderSys)
-import Carnap.Languages.ModalPropositional.Logic (ofModalPropSys)
-import Carnap.Languages.DefiniteDescription.Logic.Gamut (ofDefiniteDescSys)
-import Carnap.Calculi.NaturalDeduction.Syntax (NaturalDeductionCalc(..))
-import Carnap.GHCJS.SharedTypes
-import Carnap.GHCJS.SharedFunctions (simpleCipher,simpleHash,inOpts)
+import           Import
+
+import           Data.List                                        (nub)
+import           Data.Map                                         as M (fromList)
+import           Data.Tree
+import           Filter.Util                                      (sanitizeHtml)
+import           Text.Blaze.Html5                                 (Markup)
+import           Text.Read                                        (readMaybe)
+import           Yesod.Form.Bootstrap3
+
+import           Carnap.Calculi.NaturalDeduction.Syntax           (NaturalDeductionCalc (..))
+import           Carnap.GHCJS.SharedFunctions                     (inOpts,
+                                                                   simpleCipher,
+                                                                   simpleHash)
+import           Carnap.GHCJS.SharedTypes
+import           Carnap.Languages.DefiniteDescription.Logic.Gamut (ofDefiniteDescSys)
+import           Carnap.Languages.ModalPropositional.Logic        (ofModalPropSys)
+import           Carnap.Languages.PureFirstOrder.Logic            (ofFOLSys)
+import           Carnap.Languages.PureFirstOrder.Syntax
+import           Carnap.Languages.PurePropositional.Logic         (ofPropSys)
+import           Carnap.Languages.PurePropositional.Syntax
+import           Carnap.Languages.PureSecondOrder.Logic           (ofSecondOrderSys)
+import           Carnap.Languages.SetTheory.Logic                 (ofSetTheorySys)
+import           Util.Assignment
+import           Util.Data
+import           Util.Handler                                     (addDocScripts)
 
 deleteReviewR :: Text -> Text -> Handler Value
 deleteReviewR coursetitle asgntitle = do
@@ -56,13 +62,7 @@ getReviewR coursetitle asgntitle =
            let problems = sortBy theSorting unsortedProblems
                due = assignmentMetadataDuedate val
            defaultLayout $ do
-               addScript $ StaticR js_popper_min_js
-               addScript $ StaticR js_proof_js
-               addScript $ StaticR ghcjs_rts_js
-               addScript $ StaticR ghcjs_allactions_lib_js
-               addScript $ StaticR ghcjs_allactions_out_js
-               addStylesheet $ StaticR css_proof_css
-               addStylesheet $ StaticR css_exercises_css
+               addDocScripts
                $(widgetFile "review")
                addScript $ StaticR ghcjs_allactions_runmain_js
     where maybeLnSort (_,Nothing) (_,Nothing) = EQ

--- a/Carnap-Server/Handler/Rule.hs
+++ b/Carnap-Server/Handler/Rule.hs
@@ -80,6 +80,7 @@ getRuleR = do derivedPropRules <- getPropDrList
                                          data-carnap-submission="saveRule">
                             |]
 
+ruleLayout :: ToWidget App a => a -> HandlerFor App Html
 ruleLayout widget = do
         master <- getYesod
         mmsg <- getMessage
@@ -97,6 +98,7 @@ ruleLayout widget = do
             $(widgetFile "default-layout")
         withUrlRenderer $(hamletFile =<< pathRelativeToCabalPackage "templates/default-layout-wrapper.hamlet")
 
+getPropDrList :: HandlerFor App (Maybe [Html])
 getPropDrList = do maybeCurrentUserId <- maybeAuthId
                    case maybeCurrentUserId of
                        Nothing -> return Nothing
@@ -104,25 +106,28 @@ getPropDrList = do maybeCurrentUserId <- maybeAuthId
                                       savedRules <- getRules uid
                                       return $ Just $ formatOldPropRules savedRulesOld ++ formatPropRules savedRules
 
+getFOLDrList :: HandlerFor App (Maybe Html)
 getFOLDrList = do maybeCurrentUserId <- maybeAuthId
                   case maybeCurrentUserId of
-                       Nothing -> return Nothing
+                       Nothing  -> return Nothing
                        Just uid -> Just . formatFOLRules <$> getRules uid
 
 
+formatOldPropRules :: Functor f => f SavedDerivedRule -> f Html
 formatOldPropRules rules = map toRow rules
     where toRow (SavedDerivedRule dr n _ _) = let (Just dr') = decodeRule dr in
                                               B.tr $ do B.td $ B.toHtml $ "D-" ++ n
                                                         B.td $ B.toHtml $ intercalate "," $ map show $ premises dr'
                                                         B.td $ B.toHtml $ show $ conclusion dr'
-          toRuow _ = return ()
 
+formatPropRules :: Functor f => f SavedRule -> f Html
 formatPropRules rules = map toRow rules
     where toRow (SavedRule (PropRule dr) n _ _) = B.tr $ do B.td $ B.toHtml $ "D-" ++ n
                                                             B.td $ B.toHtml $ intercalate "," $ map show $ premises dr
                                                             B.td $ B.toHtml $ show $ conclusion dr
           toRow _ = return ()
 
+formatFOLRules :: (MonoFoldable mono, Element mono ~ SavedRule) => mono -> Html
 formatFOLRules rules = B.table B.! class_ "rules" $ do
         B.thead $ do
             B.th "Name"

--- a/Carnap-Server/Handler/Rule.hs
+++ b/Carnap-Server/Handler/Rule.hs
@@ -1,15 +1,18 @@
 module Handler.Rule where
 
-import Import
-import Text.Julius (juliusFile)
-import Text.Hamlet (hamletFile)
-import TH.RelativePaths (pathRelativeToCabalPackage)
-import Carnap.GHCJS.SharedTypes
-import Util.Database
-import qualified Data.CaseInsensitive as CI
-import qualified Data.Text.Encoding as TE
-import qualified Text.Blaze.Html5 as B
-import Text.Blaze.Html5.Attributes
+import           Import
+
+import           Carnap.GHCJS.SharedTypes
+import qualified Data.CaseInsensitive        as CI
+import qualified Data.Text.Encoding          as TE
+import qualified Text.Blaze.Html5            as B
+import           Text.Blaze.Html5.Attributes
+import           Text.Hamlet                 (hamletFile)
+import           Text.Julius                 (juliusFile)
+import           TH.RelativePaths            (pathRelativeToCabalPackage)
+
+import           Util.Database
+import           Util.Handler                (addDocScripts)
 
 getRuleR :: Handler Html
 getRuleR = do derivedPropRules <- getPropDrList
@@ -87,15 +90,11 @@ ruleLayout widget = do
         let isInstructor = not $ null (mud >>= userDataInstructorId . entityVal)
         pc <- widgetToPageContent $ do
             toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/command.julius")
-            addScript $ StaticR ghcjs_rts_js
-            addScript $ StaticR ghcjs_allactions_lib_js
-            addScript $ StaticR ghcjs_allactions_out_js
-            addStylesheet $ StaticR css_tree_css
+
+            addDocScripts
             addStylesheet $ StaticR css_tufte_css
             addStylesheet $ StaticR css_tuftextra_css
-            addStylesheet $ StaticR css_exercises_css
             $(widgetFile "default-layout")
-            addScript $ StaticR ghcjs_allactions_runmain_js
         withUrlRenderer $(hamletFile =<< pathRelativeToCabalPackage "templates/default-layout-wrapper.hamlet")
 
 getPropDrList = do maybeCurrentUserId <- maybeAuthId

--- a/Carnap-Server/Handler/Serve.hs
+++ b/Carnap-Server/Handler/Serve.hs
@@ -50,15 +50,8 @@ getServeR base components = do app <- getYesod
                       mcss <- retrievePandocVal (lookupMeta "css" meta)
                       mjs <- retrievePandocVal (lookupMeta "js" meta)
                       defaultLayout $ do
-                          addScript $ StaticR js_proof_js
-                          addScript $ StaticR js_popper_min_js
-                          addScript $ StaticR ghcjs_rts_js
-                          addScript $ StaticR ghcjs_allactions_lib_js
-                          addScript $ StaticR ghcjs_allactions_out_js
+                          addDocScripts
                           maybe (pure [()]) (mapM (addScriptRemote))  mjs
-                          addStylesheet $ StaticR css_tree_css
-                          addStylesheet $ StaticR css_proof_css
-                          addStylesheet $ StaticR css_exercises_css
                           case mcss of
                               Nothing -> mapM addStylesheet [StaticR css_bootstrapextra_css]
                               Just ss -> mapM addStylesheetRemote ss

--- a/Carnap-Server/Handler/Serve.hs
+++ b/Carnap-Server/Handler/Serve.hs
@@ -64,13 +64,3 @@ getServeR base components = do app <- getYesod
                               Just ss -> mapM addStylesheetRemote ss
                           $(widgetFile "document")
                           addScript $ StaticR ghcjs_allactions_runmain_js
-
-allFilters = makeTreeDeduction
-             . makeSequent
-             . makeSynCheckers
-             . makeProofChecker
-             . makeTranslate
-             . makeTruthTables
-             . makeCounterModelers
-             . makeQualitativeProblems
-             . renderFormulas

--- a/Carnap-Server/Handler/Serve.hs
+++ b/Carnap-Server/Handler/Serve.hs
@@ -1,32 +1,17 @@
 module Handler.Serve where
 
-import Import
-import System.Directory (doesFileExist)
-import Yesod.Markdown
-import Data.List (nub)
-import Text.Pandoc (writerExtensions,writerWrapText, WrapOption(..), readerExtensions, Pandoc(..), lookupMeta)
-import Text.Pandoc.Walk (walkM, walk)
-import Text.Julius (juliusFile,rawJS)
-import TH.RelativePaths (pathRelativeToCabalPackage)
-import System.FilePath as FP (takeExtension,joinPath)
-import Util.Data
-import Util.Database
-import Util.Handler
-import Filter.SynCheckers
-import Filter.ProofCheckers
-import Filter.Translate
-import Filter.TruthTables
-import Filter.CounterModelers
-import Filter.Qualitative
-import Filter.Sequent
-import Filter.TreeDeduction
-import Filter.RenderFormulas
+import           Import
+import           System.Directory (doesFileExist)
+import           System.FilePath  as FP (joinPath, takeExtension)
+import           Text.Pandoc      (lookupMeta)
+import           Util.Handler
+
 
 -- XXX DRY up the boilplate that is shared by getDocumentDownload
 getServeR :: Text -> [Text] -> Handler Html
 getServeR base components = do app <- getYesod
                                let root = appDataRoot $ appSettings app
-                               path <- case components of 
+                               path <- case components of
                                          [] -> redirect $ ServeR base [pack "index.md"]
                                          _ -> return $ FP.joinPath (unpack root:"srv":unpack base:map unpack components)
                                liftIO (doesFileExist path) >>= \exists -> if exists then return () else notFound

--- a/Carnap-Server/Util/Data.hs
+++ b/Carnap-Server/Util/Data.hs
@@ -44,9 +44,9 @@ data APIKeyScope = APIKeyScopeRoot
     deriving (Show, Read, Eq)
 derivePersistField "APIKeyScope"
 
-data AvailabilityStatus = ViaPassword Text 
+data AvailabilityStatus = ViaPassword Text
                         | HiddenViaPassword Text
-                        | ViaPasswordExpiring Text Int 
+                        | ViaPasswordExpiring Text Int
                         | HiddenViaPasswordExpiring Text Int
     deriving (Show, Read, Eq, Generic)
 instance ToJSON AvailabilityStatus
@@ -66,8 +66,17 @@ availabilityMinutes (ViaPasswordExpiring _ min) = Just min
 availabilityMinutes (HiddenViaPasswordExpiring _ min) = Just min
 availabilityMinutes _ = Nothing
 
+sanitizeForJS :: String -> String
+sanitizeForJS ('\n':xs) = '\\' : 'n' : sanitizeForJS xs
+sanitizeForJS ('\\':xs) = '\\' : '\\' : sanitizeForJS xs
+sanitizeForJS ('\'':xs) = '\\' : '\'' : sanitizeForJS xs
+sanitizeForJS ('"':xs)  = '\\' : '"' : sanitizeForJS xs
+sanitizeForJS ('\r':xs) = sanitizeForJS xs
+sanitizeForJS (x:xs) = x : sanitizeForJS xs
+sanitizeForJS [] = []
+
 chapterOfProblemSet :: IntMap Int
-chapterOfProblemSet = IM.fromList 
+chapterOfProblemSet = IM.fromList
     [ (1,1)
     , (2,2)
     , (3,2)
@@ -87,7 +96,7 @@ chapterOfProblemSet = IM.fromList
     , (17,12)
     ]
 
-carnapPandocExtensions = extensionsFromList 
+carnapPandocExtensions = extensionsFromList
         [ Ext_raw_html
         , Ext_markdown_in_html_blocks
         , Ext_auto_identifiers
@@ -139,8 +148,8 @@ displayProblemData (TruthTableDataOpts t _ opts') = maybe (rewriteText opts t) p
                `mplus` (intercalate "," . map (rewriteWith opts . show) <$> (readMaybe s :: Maybe [PureForm]))
                `mplus` case readMaybe s :: Maybe ([PureForm],[PureForm]) of
                                  Nothing -> Nothing
-                                 Just (fs,gs) -> Just $ intercalate "," (map (rewriteWith opts . show) fs) 
-                                                      ++ " || " 
+                                 Just (fs,gs) -> Just $ intercalate "," (map (rewriteWith opts . show) fs)
+                                                      ++ " || "
                                                       ++ intercalate "," (map (rewriteWith opts . show) gs)
           s = unpack t
 displayProblemData (TranslationData t _) = "-"

--- a/Carnap-Server/static/truth-tree/lib.css
+++ b/Carnap-Server/static/truth-tree/lib.css
@@ -1,0 +1,1 @@
+../../../truth-tree-out/dist/lib.css

--- a/Carnap-Server/static/truth-tree/lib.js
+++ b/Carnap-Server/static/truth-tree/lib.js
@@ -1,0 +1,1 @@
+../../../truth-tree-out/dist/lib.js

--- a/Carnap-Server/templates/assignment-state.julius
+++ b/Carnap-Server/templates/assignment-state.julius
@@ -9,7 +9,7 @@ var CarnapServerAPI = {
     },
     assignment: {
         /* toMS to get milliseconds for JS */
-        dueDate: #{jsMaybe (show . (toMS . (round . utcTimeToPOSIXSeconds))) (assignmentMetadataDuedate val)},
+        dueDate: #{jsMaybe toJsTime (assignmentMetadataDuedate val)},
         pointValue: #{jsMaybe show (assignmentMetadataPointValue val)},
         totalProblems: #{jsMaybe show (assignmentMetadataTotalProblems val)},
         description: #{jsMaybe show (assignmentMetadataDescription val)},

--- a/Carnap-Server/templates/createTrees.julius
+++ b/Carnap-Server/templates/createTrees.julius
@@ -1,0 +1,8 @@
+if (document.TruthTrees && document.TruthTrees.length) {
+  const scriptTag = document.createElement("script");
+  scriptTag.src = "@{StaticR truth_tree_lib_js}";
+  scriptTag.onload = (_err) => {
+    return document.TruthTrees.forEach((args) => Rudolf.createTree(...args));
+  };
+  document.body.appendChild(scriptTag);
+}

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ build-docker:
 
 devel: build-ghcjs run
 
+APPROOT := "http://localhost:3000"
+DATAROOT := "../dataroot"
+BOOKROOT := "../books/Carnap-Book/"
+
 run:
 ifeq ($(origin NIX_STORE),undefined)
 	nix-shell --run 'make run'

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ devel: build-ghcjs run
 
 APPROOT := "http://localhost:3000"
 DATAROOT := "../dataroot"
-BOOKROOT := "../books/Carnap-Book/"
+BOOKROOT := "../Carnap-Book/"
 
 run:
 ifeq ($(origin NIX_STORE),undefined)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ APPROOT := "http://localhost:3000"
 DATAROOT := "../dataroot"
 BOOKROOT := "../Carnap-Book/"
 
-run:
+run: client-out truth-tree-out
 ifeq ($(origin NIX_STORE),undefined)
 	nix-shell --run 'make run'
 else
@@ -61,10 +61,18 @@ else
 		cabal run $(CABALFLAGS) Carnap-Server $(CONFIGFILE)
 endif
 
+# builds the client files
+client-out:
+	nix-build -A client -o client-out
+
+# builds the truth tree module
+truth-tree-out:
+	nix-build -A truth-tree -o truth-tree-out
+
 shell-ghc:
 	nix-shell
 
-build-ghc:
+build-ghc: client-out truth-tree-out
 ifeq ($(origin NIX_STORE),undefined)
 	nix-shell --run 'make build-ghc'
 else

--- a/default.nix
+++ b/default.nix
@@ -29,6 +29,7 @@ let
     };
 
   client = nixpkgs-stable.haskell.packages."${ghcjsVer}".Carnap-GHCJS;
+  truth-tree = import sources.truth-tree { inherit nixpkgs; };
 
   nixpkgs = import sources.nixpkgs {
       config = {
@@ -40,7 +41,7 @@ let
         (import ./nix/compose-haskell-overlays.nix {
           inherit ghcVer;
           overlays = [
-            (import ./server.nix { inherit profiling client; inherit (sources) persistent; })
+            (import ./server.nix { inherit profiling truth-tree client ; inherit (sources) persistent; })
           ];
         })
       ];
@@ -63,7 +64,7 @@ let
   ]);
 
   in rec {
-    inherit nixpkgs nixpkgs-stable client;
+    inherit nixpkgs nixpkgs-stable client truth-tree;
     server = nixpkgs.haskell.packages."${ghcVer}".Carnap-Server;
 
     # a ghc-based shell for development of Carnap and Carnap-Server

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -34,5 +34,17 @@
         "type": "tarball",
         "url": "https://github.com/yesodweb/persistent/archive/1cdadc10405e9e3b1e0e73e2c1d6ec84eed69a53.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "truth-tree": {
+        "branch": "nix-building",
+        "description": "Truth Tree Widget for Carnap",
+        "homepage": "",
+        "owner": "ubc-carnap-team",
+        "repo": "Rudolf",
+        "rev": "08bdb487ad403e8a94820fe6e32aa83509f0a6c1",
+        "sha256": "1pv4fb18mg4870wn4a4lvg9hdbrgyc7ah3931x579zajnkx53y9h",
+        "type": "tarball",
+        "url": "https://github.com/ubc-carnap-team/Rudolf/archive/08bdb487ad403e8a94820fe6e32aa83509f0a6c1.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -36,15 +36,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "truth-tree": {
-        "branch": "nix-building",
+        "branch": "master",
         "description": "Truth Tree Widget for Carnap",
         "homepage": "",
         "owner": "ubc-carnap-team",
         "repo": "Rudolf",
-        "rev": "08bdb487ad403e8a94820fe6e32aa83509f0a6c1",
-        "sha256": "1pv4fb18mg4870wn4a4lvg9hdbrgyc7ah3931x579zajnkx53y9h",
+        "rev": "cd015948701a8181c5e6c908988aae58ee5325c8",
+        "sha256": "1i3vp2qy00j8n18wbgqwa4lgwndl7019zmyw3zx3qigpw8hhsrw4",
         "type": "tarball",
-        "url": "https://github.com/ubc-carnap-team/Rudolf/archive/08bdb487ad403e8a94820fe6e32aa83509f0a6c1.tar.gz",
+        "url": "https://github.com/ubc-carnap-team/Rudolf/archive/cd015948701a8181c5e6c908988aae58ee5325c8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/server.nix
+++ b/server.nix
@@ -1,4 +1,4 @@
-{ client, persistent, withHoogle ? true, profiling ? false }:
+{ client, truth-tree, persistent, withHoogle ? true, profiling ? false }:
 { nixpkgs }:
 let
   inherit (nixpkgs.lib) gitignoreSource;
@@ -80,6 +80,11 @@ newpkgs: oldpkgs: {
         cp ${client.out}/bin/AllActions.jsexe/out.js static/ghcjs/allactions/
         cp ${client.out}/bin/AllActions.jsexe/lib.js static/ghcjs/allactions/
         cp ${client.out}/bin/AllActions.jsexe/runmain.js static/ghcjs/allactions/
+
+        find static/truth-tree -type l -delete
+        cp ${truth-tree.out}/dist/lib.css static/truth-tree/
+        cp ${truth-tree.out}/dist/lib.js  static/truth-tree/
+
         echo ":: Adding a universal settings file"
         cp config/settings-example.yml config/settings.yml
         cp -r {config,static} $out/share
@@ -88,7 +93,7 @@ newpkgs: oldpkgs: {
 
       enableExecutableProfiling = profiling;
       enableLibraryProfiling = profiling;
-      buildDepends = [ book client ];
+      buildDepends = [ book client truth-tree ];
 
       isExecutable = true;
       # Carnap-Server has no tests/they are broken


### PR DESCRIPTION
This integrates https://github.com/ubc-carnap-team/Rudolf truth trees into Carnap using a new filter.

Note that I've split this one into separate commits to keep the stuff that needs careful review separate from the bunches of mechanical changes. I think I fixed up about 30 compiler warnings with this change set.

This might need some testing with other documents and some other routes as I don't *think* the coincidental reorganizing of the JS include order that happened here should matter much, but I am not 100% confident.

![image](https://user-images.githubusercontent.com/6652840/124901167-9c948680-df96-11eb-94f3-ef0faa51af19.png)


Here's a demo document that works with these changes, that @McTano wrote:

````pandoc
Semantic Tableau Demo
========

Our team at UBC has extended the Carnap framework to support interactive proving using the semantic tableau method. By listing the initial formulas needed for a proof in a textbook page or worksheet, an instructor can insert an interactive widget for students to complete the proof.

For example, here is an exercise which shows that the set of formulas $\{P,P \rightarrow Q,\neg P\}$ is inconsistent.

```{.TruthTree .Prop}
1.1 P,P->Q,~Q
```

This is also a proof that the argument $P, P\rightarrow Q \models Q$ is valid.

We can also give the student an empty widget, and ask them to prove a truth-theoretic statement.

1.2 Prove that the following argument is valid:
> | <span class="premise"> $\neg A \lor \neg B$</span>
> | <span class="premise"> $\neg B \lor A$</span>
> | <span class="conclusion"> $\neg B$</span>
$\neg S \land P,\neg P \lor R \models R$ is valid.
```{.TruthTree .Prop}
1.2 
```

The propositional logic system **SL** used in the UBC version of the *forall x* textbook is currently supported. We plan to support Quantified (First Order) Logic (**QL** in *forall x*), as well as variations used by other textbooks.
````