### PR TITLE
Log anonymized LTI tokens in prod

### DIFF
--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -261,6 +261,7 @@ instance Yesod App where
     -- in development, and warnings and errors in production.
     shouldLogIO app _source level = return $
         appShouldLogAll (appSettings app)
+            || level == LevelInfo
             || level == LevelWarn
             || level == LevelError
 

--- a/server.nix
+++ b/server.nix
@@ -51,13 +51,13 @@ newpkgs: oldpkgs: {
   # yesod-auth-lti13 = oldpkgs.callCabal2nix "yesod-auth-lti13" ../lti13/yesod-auth-lti13 { };
   lti13 = oldpkgs.callHackageDirect {
     pkg = "lti13";
-    ver = "0.2.0.0";
-    sha256 = "0j6pjrmpps36ppg750wnmksvpgv2i14pfzpwg3zxhzpniigpxd4x";
+    ver = "0.2.0.2";
+    sha256 = "014pmhl28z242pmmkn63sh7ijdjlh2f7fbq8l5bc0q6llcd6if7y";
   } { };
   yesod-auth-lti13 = oldpkgs.callHackageDirect {
     pkg = "yesod-auth-lti13";
-    ver = "0.2.0.0";
-    sha256 = "130ylr7prhw9j5lx5wni70nb2v72jcc9l7l6zk30camg1q96r2mg";
+    ver = "0.2.0.2";
+    sha256 = "0q2vy7zdv5sm09wh2cqslgz0yh8l4h2gd7w1024i2mgblxa8v4xw";
   } { };
 
   # dontCheck: https://github.com/gleachkr/Carnap/issues/123

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,8 +20,8 @@ extra-deps:
           - persistent-postgresql
           - persistent-template
           - persistent-qq
-    - lti13-0.2.0.0
-    - yesod-auth-lti13-0.2.0.0
+    - lti13-0.2.0.2
+    - yesod-auth-lti13-0.2.0.2
     - oidc-client-0.5.1.0
 
 # :( persistent bug fix requires a git version, which means we have to turn off


### PR DESCRIPTION
This should make it easier to deal with future issues with LTI as we no longer need to get tokens from people if there are problems with them: one can instead look at the server logs.

You can see the anonymization logic here: https://github.com/lf-/lti13/blob/main/lti13/src/Web/LTI13.hs#L518-L553. It erases everything about the individual student and keeps the information such as course and others that we might need to debug/find the offending token.

I also fixed all the compile warnings in Util.Data because there seemed to be a fair few.