### PR TITLE
Fix all fixable compiler warnings

### DIFF
--- a/Carnap-Server/Filter/Randomize.hs
+++ b/Carnap-Server/Filter/Randomize.hs
@@ -1,10 +1,11 @@
+{-# LANGUAGE PatternGuards #-}
 module Filter.Randomize (randomizeProblems) where
 
-import Data.List
-import Data.Hashable
-import Text.Pandoc
-import System.Random
-import Prelude
+import           Data.Hashable
+import           Data.List
+import           Prelude
+import           System.Random
+import           Text.Pandoc
 
 randomizeProblems :: Int -> Block -> Block
 randomizeProblems salt (Div ("",[],[]) contents) = Div ("",[],[]) (randomize salt contents)

--- a/Carnap-Server/Handler/API/Instructor/Courses.hs
+++ b/Carnap-Server/Handler/API/Instructor/Courses.hs
@@ -1,11 +1,6 @@
 module Handler.API.Instructor.Courses where
 
 import           Data.Aeson
-import           Data.Time
-import           Data.Time.Zones
-import           Data.Time.Zones.DB
-import           Data.Time.Zones.All
-import qualified Data.HashMap.Strict as HM
 import           Import
 import           Util.Handler
 

--- a/Carnap-Server/Handler/API/Instructor/Students.hs
+++ b/Carnap-Server/Handler/API/Instructor/Students.hs
@@ -4,54 +4,50 @@ import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Time
 import           Data.Time.Zones
-import           Data.Time.Zones.DB
 import           Data.Time.Zones.All
 import           Import
-import           Util.Data           (SharingScope (..))
+import           Util.Database       (problemQuery)
 import           Util.Handler
-import           Util.Database (problemQuery)
-import           System.Directory
-import           System.FilePath
 
 getAPIInstructorStudentsR :: Text -> Text -> Handler Value
-getAPIInstructorStudentsR ident coursetitle = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+getAPIInstructorStudentsR ident coursetitle = do
+             Entity cid _course <- canAccessClass ident coursetitle
              students <- runDB $ selectList [UserDataEnrolledIn ==. Just cid] []
              returnJson students
 
 getAPIInstructorStudentR :: Text -> Text -> UserDataId -> Handler Value
-getAPIInstructorStudentR ident coursetitle udid = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+getAPIInstructorStudentR ident coursetitle udid = do
+             Entity cid _course <- canAccessClass ident coursetitle
              student <- runDB $ studentEnrolled udid cid
              returnJson student
 
 getAPIInstructorStudentSubmissionsR :: Text -> Text -> UserDataId -> Handler Value
-getAPIInstructorStudentSubmissionsR ident coursetitle udid = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+getAPIInstructorStudentSubmissionsR ident coursetitle udid = do
+             Entity cid _course <- canAccessClass ident coursetitle
              subs <- runDB $ do asmd <- selectList [AssignmentMetadataCourse ==. cid] []
                                 ud <- studentEnrolled udid cid
-                                let pq = problemQuery (userDataUserId ud) (map entityKey asmd) 
+                                let pq = problemQuery (userDataUserId ud) (map entityKey asmd)
                                 selectList pq []
              returnJson (map entityVal subs)
 
 getAPIInstructorStudentExtensionsR :: Text -> Text -> UserDataId -> Handler Value
-getAPIInstructorStudentExtensionsR ident coursetitle udid = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+getAPIInstructorStudentExtensionsR ident coursetitle udid = do
+             Entity cid _course <- canAccessClass ident coursetitle
              extensions <- runDB $ do ud <- studentEnrolled udid cid
                                       selectList [ExtensionForUser ==. userDataUserId ud] []
              returnJson extensions
 
 postAPIInstructorStudentExtensionsR :: Text -> Text -> UserDataId -> Handler Value
-postAPIInstructorStudentExtensionsR ident coursetitle udid = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+postAPIInstructorStudentExtensionsR ident coursetitle udid = do
+             Entity cid course <- canAccessClass ident coursetitle
              val <- requireCheckJsonBody :: Handler Value
              case parse (unpackPost course) val of
                  Error e -> sendStatusJSON badRequest400 e
                  Success (aid,until) -> do
                      Entity exid _ <- runDB $ do
                          ud <- studentEnrolled udid cid
-                         assignmentPartOf aid cid --verify that the assignemnt belongs to this class
-                         upsertBy (UniqueExtension aid (userDataUserId ud)) 
+                         _ <- assignmentPartOf aid cid --verify that the assignemnt belongs to this class
+                         upsertBy (UniqueExtension aid (userDataUserId ud))
                                   (Extension aid (userDataUserId ud) until)
                                   [ExtensionUntil =. until]
                      returnJson exid
@@ -72,16 +68,16 @@ postAPIInstructorStudentExtensionsR ident coursetitle udid = do
               return $ localTimeToUTCTZ tz localTime
 
 getAPIInstructorStudentAccommodationsR :: Text -> Text -> UserDataId -> Handler Value
-getAPIInstructorStudentAccommodationsR ident coursetitle udid = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+getAPIInstructorStudentAccommodationsR ident coursetitle udid = do
+             Entity cid _course <- canAccessClass ident coursetitle
              maccommodations <- runDB $ do ud <- studentEnrolled udid cid
                                            getBy (UniqueAccommodation cid (userDataUserId ud))
              returnJson maccommodations
 
 data AccommodationPatch = AccommodationPatch
-                       { patchTimeFactor :: Maybe Double
+                       { patchTimeFactor       :: Maybe Double
                        , patchTimeExtraMinutes :: Maybe Int
-                       , patchDateExtraHours :: Maybe Int
+                       , patchDateExtraHours   :: Maybe Int
                        }
 
 instance FromJSON AccommodationPatch where
@@ -91,11 +87,11 @@ instance FromJSON AccommodationPatch where
                               <*> (o .:? "dateExtraHours")
 
 patchAPIInstructorStudentAccommodationsR :: Text -> Text -> UserDataId -> Handler Value
-patchAPIInstructorStudentAccommodationsR ident coursetitle udid = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+patchAPIInstructorStudentAccommodationsR ident coursetitle udid = do
+             Entity cid _course <- canAccessClass ident coursetitle
              patch <- requireCheckJsonBody :: Handler AccommodationPatch
              newaccommodation <- runDB $ do ud <- studentEnrolled udid cid
-                                            upsertBy 
+                                            upsertBy
                                                 (UniqueAccommodation cid (userDataUserId ud))
                                                 (Accommodation { accommodationForCourse = cid
                                                                , accommodationForUser = userDataUserId ud
@@ -111,25 +107,25 @@ patchAPIInstructorStudentAccommodationsR ident coursetitle udid = do
           maybeUpdate _     Nothing    = []
 
 getAPIInstructorStudentAssignmentTokensR :: Text -> Text -> UserDataId -> Handler Value
-getAPIInstructorStudentAssignmentTokensR ident coursetitle udid = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+getAPIInstructorStudentAssignmentTokensR ident coursetitle udid = do
+             Entity cid _course <- canAccessClass ident coursetitle
              tokens <- runDB $ do ud <- studentEnrolled udid cid
                                   alltokens <- selectList [AssignmentAccessTokenUser ==. userDataUserId ud] []
                                   filterM (\(Entity _ tok) -> tokenCourse tok >>= \mcid -> return (mcid == Just cid)) alltokens
              returnJson tokens
 
 deleteAPIInstructorStudentAssignmentTokenR :: Text -> Text -> UserDataId -> AssignmentAccessTokenId -> Handler Value
-deleteAPIInstructorStudentAssignmentTokenR ident coursetitle udid tokid = do 
-             courseEnt@(Entity cid course) <- canAccessClass ident coursetitle
+deleteAPIInstructorStudentAssignmentTokenR ident coursetitle _udid tokid = do
+             Entity cid _course <- canAccessClass ident coursetitle
              runDB $ do tok <- get tokid >>= maybe (sendStatusJSON notFound404 ("No available token for this id" :: Text)) pure
                         mcid <- tokenCourse tok
-                        if mcid == Just cid 
+                        if mcid == Just cid
                             then delete tokid
                             else sendStatusJSON notFound404 ("No available token for this id" :: Text)
              returnJson ("deleted token" :: Text)
 
 studentEnrolled :: (YesodPersist site, YesodPersistBackend site ~ SqlBackend) => UserDataId -> CourseId -> YesodDB site UserData
-studentEnrolled udid cid = do 
+studentEnrolled udid cid = do
         ud <- get udid >>= maybe (sendStatusJSON notFound404 ("No userdata for this ident" :: Text)) pure
         if userDataEnrolledIn ud == Just cid then return () else sendStatusJSON notFound404 ("No userdata for this ident" :: Text)
         return ud

--- a/Carnap-Server/Handler/Book.hs
+++ b/Carnap-Server/Handler/Book.hs
@@ -1,26 +1,27 @@
 module Handler.Book where
 
-import Import
-import System.Directory (getDirectoryContents, doesDirectoryExist)
+import           Import
+import           System.Directory (getDirectoryContents)
 
 -- XXX: for uniformity, merge this with ChapterR
 
 getBookR :: Handler Html
 getBookR = do bookdir <- appBookRoot <$> (appSettings <$> getYesod)
               cdir <- liftIO $ getDirectoryContents bookdir
-              let ccount = zip (map getTitle $ filter ctitle cdir) [1 ..] 
-              let acount = zip3 (map getTitle $ filter atitle  cdir) [1 ..] [length ccount + 1 ..]
+              let ccount = zip (map getTitle $ filter ctitle cdir) [1 :: Integer ..]
+              let acount = zip3 (map getTitle $ filter atitle cdir) [1 :: Integer ..] [length ccount + 1 ..]
               defaultLayout $ do
                   setTitle $ "The Carnap Book"
                   $(widgetFile "carnap-book")
     where ctitle x = take 7 x == "chapter"
           atitle x = take 8 x == "appendix"
 
+getTitle :: [Char] -> Maybe [Char]
 getTitle s = case break (== '_') s of
                (_,[]) -> Nothing
-               (_,a)  -> 
+               (_,a)  ->
                   case break (== '_') (drop 1 a) of
                       (_, []) -> Nothing
-                      (b, _) -> Just b
+                      (b, _)  -> Just b
 
 -- TODO: get pandoc metadata from chapters, including TOC links and titles

--- a/Carnap-Server/Handler/Document.hs
+++ b/Carnap-Server/Handler/Document.hs
@@ -109,15 +109,15 @@ getDocumentR ident title = do (Entity _key doc, path, creatorid) <- retrieveDoc 
                       mcss <- retrievePandocVal (lookupMeta "css" meta)
                       mjs <- retrievePandocVal (lookupMeta "js" meta)
                       let theLayout = \widget -> case mbcss of
-                                       Nothing -> defaultLayout $ do mapM addStylesheet [StaticR css_bootstrapextra_css]
+                                       Nothing -> defaultLayout $ do addStylesheet $ StaticR css_bootstrapextra_css
                                                                      widget
-                                       Just bcss -> cleanLayout $ do mapM addStylesheetRemote bcss
+                                       Just bcss -> cleanLayout $ do mapM_ addStylesheetRemote bcss
                                                                      widget
                       theLayout $ do
                           toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/command.julius")
                           addDocScripts
-                          maybe (pure [()]) (mapM addScriptRemote) mjs
-                          maybe (pure [()]) (mapM addStylesheetRemote) mcss
+                          mapM_ addScriptRemote $ concat mjs
+                          mapM_ addStylesheetRemote $ concat mcss
                           $(widgetFile "document")
 
 getDocumentDownloadR :: Text -> Text -> Handler TypedContent

--- a/Carnap-Server/Handler/Info.hs
+++ b/Carnap-Server/Handler/Info.hs
@@ -27,11 +27,14 @@ checker n thetype sys opts goal proof =
         |]
     where strip = dropWhile (== '\n')
 
+proofcheck :: Int -> Text -> Text -> Text -> Text -> HtmlUrl url
 proofcheck n = checker n "proofchecker"
 
+sequentcheck :: Int -> Text -> Text -> Text -> Text -> HtmlUrl url
 sequentcheck n = checker n "sequentchecker"
 
 -- XXX function that strips text of indentation and line-numbers.
+aristotleTheorem :: Text
 aristotleTheorem = [st|
 Show: P\/-P
     Show: --(P\/-P)
@@ -45,6 +48,7 @@ Show: P\/-P
     P\/-P:DNE 2
 :DD 10|]
 
+pierceTheorem :: Text
 pierceTheorem = [st|
   (P->Q)->P     :A/CI
      -P         :A/~E
@@ -59,6 +63,7 @@ pierceTheorem = [st|
   P             :2-10 -E
 ((P->Q)->P)->P  :1-11 CI |]
 
+lemmonTheorem :: Text
 lemmonTheorem = [st|
 [1]       ExAy(Kxy -> Fxy) P
 [2]       AxEy(Kxy)        P
@@ -72,6 +77,7 @@ lemmonTheorem = [st|
 [1,2,3]   ExEyFxy          [5](9) EIE
 [1,2]     ExEyFxy          [3](10) EIE|]
 
+comprehensionTheorem :: Text
 comprehensionTheorem = [st|
 Show EXAx(F(x)/\G(x)<->X(x))
    Show Ax(F(x)/\G(x)<->\y[F(y)/\G(y)](x))
@@ -88,6 +94,7 @@ Show EXAx(F(x)/\G(x)<->X(x))
    EXAx(F(x)/\G(x)<->X(x)):EG 2
 :DD 13|]
 
+russellTheorem :: Text
 russellTheorem = [st|
 Show -ExAy(-F(y,y) <-> F(x,y))
     ExAy(-F(y,y)<->F(x,y))          :AS
@@ -106,6 +113,7 @@ Show -ExAy(-F(y,y) <-> F(x,y))
     :ED 13 2 4
 :ID 2 3|]
 
+russellTheoremForallx :: Text
 russellTheoremForallx = [st|
     ExAy(-Fyy <-> Fxy):AS
        Ay(-Fyy<->Fry):AS
@@ -123,6 +131,7 @@ russellTheoremForallx = [st|
     ExAy(-Fyy <-> Fxy):R 1
 -ExAy(-Fyy <-> Fxy):-I 1-14|]
 
+russellTheoremCalgary :: Text
 russellTheoremCalgary = [st|
     ExAy(-Fyy <-> Fxy):AS
         Ay(-Fyy<->Fry):AS
@@ -138,6 +147,7 @@ russellTheoremCalgary = [st|
     !?:EE 1 2-11
 -ExAy(-Fyy <-> Fxy):-I 1-12|]
 
+inverseTheorem :: Text
 inverseTheorem = [st|
 Show: AX2EY2∀x∀y(X2(x,y) ↔ Y2(y,x))
   Show: ∀x∀y(X2(x,y) ↔ \w\v[X2(v,w)](y,x))
@@ -156,6 +166,7 @@ Show: AX2EY2∀x∀y(X2(x,y) ↔ Y2(y,x))
   EY2∀x∀y(X2(x,y) ↔ Y2(y,x)):EG2 2
 :UD2 15|]
 
+adjunctionTheorem :: Text
 adjunctionTheorem = [st|
 Show P->(Q->R):CD
     P:AS
@@ -165,6 +176,7 @@ Show P->(Q->R):CD
       P/\Q:&I 2 4
       R:->O 5 6|]
 
+axiomFiveTheorem :: Text
 axiomFiveTheorem = [st|
 Show <>[]P->[]P  /0   :CD
   <>[]P          /0   :AS
@@ -173,12 +185,14 @@ Show <>[]P->[]P  /0   :CD
       []P        /0-2 :<>O 2
       P          /0-1 :[]O(5) 5|]
 
+axiomBTheorem :: Text
 axiomBTheorem = [st|
 Show <>[]P->P /0   :CD
   <>[]P       /0   :AS
   []P         /0-1 :<>O 2
   P           /0   :[]O(b) 3|]
 
+barcanTheorem :: Text
 barcanTheorem = [st|
 Show Ax[]Fx->[]AxFx  /0   :CD
   Ax[]Fx             /0   :AS
@@ -188,6 +202,7 @@ Show Ax[]Fx->[]AxFx  /0   :CD
         []Fa         /0   :AO 2
         Fa           /0-1 :[]O 6|]
 
+bisectorTheorem :: Text
 bisectorTheorem = [st|
 AxAyAz(F(x,g(y,z)) ↔ h(x,y) = h(x,z)) :PR
 Show AwAxAyAz(F(w,g(x,y))∧F(w,g(x,z)) → F(w,g(y,z)))
@@ -217,6 +232,7 @@ Show AwAxAyAz(F(w,g(x,y))∧F(w,g(x,z)) → F(w,g(y,z)))
  :UD 4
 :UD 3|]
 
+transitiveTheorem :: Text
 transitiveTheorem = [st|
 Show P(a) within P(P(a))
  a within P(a):PR
@@ -244,6 +260,7 @@ Show P(a) within P(P(a))
  P(a) within P(P(a)):Def-S 4
 :DD 24|]
 
+sequentDemo :: Text
 sequentDemo = [st|
 {"ident":0,"label":"AxEy(F(x)/\\G(y)):|-:EyAx(F(x)/\\G(y))","rule":"ER","forest":[{"ident":1,"label":"AxEy(F(x)/\\G(y)) :|-: EyAx(F(x)/\\G(y)), Ax(F(x)/\\G(b))","rule":"AL","forest":[{"ident":2,"label":"Ey(F(a)/\\G(y)), AxEy(F(x)/\\G(y)) :|-: Ax(F(x)/\\G(b)), EyAx(F(x)/\\G(y))","rule":"EL","forest":[{"ident":3,"label":"F(a)/\\G(c), AxEy(F(x)/\\G(y)) :|-: Ax(F(x)/\\G(b)), EyAx(F(x)/\\G(y))","rule":"&L","forest":[{"ident":4,"label":"G(c), AxEy(F(x)/\\G(y)) :|-: EyAx(F(x)/\\G(y)), Ax(F(x)/\\G(b))","rule":"AR","forest":[{"ident":5,"label":"G(c), AxEy(F(x)/\\G(y)) :|-: EyAx(F(x)/\\G(y)), F(d)/\\G(b)","rule":"&R","forest":[{"ident":6,"label":"AxEy(F(x)/\\G(y)), G(c) :|-: EyAx(F(x)/\\G(y)),F(d)","rule":"AL","forest":[{"ident":7,"label":"Ey(F(d)/\\G(y)), G(c) :|-: F(d), EyAx(F(x)/\\G(y))","rule":"EL","forest":[{"ident":8,"label":"F(d)/\\G(e), G(c) :|-: F(d), EyAx(F(x)/\\G(y))","rule":"&L","forest":[{"ident":9,"label":"F(d), G(c) :|-: EyAx(F(x)/\\G(y)), F(d)","rule":"WR","forest":[{"ident":10,"label":"F(d), G(c) :|-: F(d)","rule":"WL","forest":[{"ident":28,"label":"F(d) :|-: F(d)","rule":"Ax","forest":[{"ident":29,"label":"","rule":"","forest":[]}]}]}]}]}]}]},{"ident":11,"label":"AxEy(F(x)/\\G(y)), G(c):|-:EyAx(F(x)/\\G(y)),G(b)","rule":"XR","forest":[{"ident":11,"label":"AxEy(F(x)/\\G(y)), G(c):|-:G(b),EyAx(F(x)/\\G(y))","rule":"ER","forest":[{"ident":12,"label":"AxEy(F(x)/\\G(y)), G(c):|-:G(b),Ax(F(x)/\\G(c))","rule":"AR","forest":[{"ident":13,"label":"AxEy(F(x)/\\G(y)),G(c) :|-: G(b), F(a)/\\G(c)","rule":"AL","forest":[{"ident":14,"label":"Ey(F(a)/\\G(y)),G(c) :|-:G(b), F(a)/\\G(c)","rule":"EL","forest":[{"ident":15,"label":"F(a)/\\G(d),G(c) :|-:F(a)/\\G(c), G(b)","rule":"&L","forest":[{"ident":16,"label":"F(a), G(c) :|-:G(b), F(a)/\\G(c)","rule":"&R","forest":[{"ident":17,"label":"G(c),F(a) :|-: G(b), G(c)","rule":"WL","forest":[{"ident":18,"label":"G(c):|-:G(b),G(c)","rule":"WR","forest":[{"ident":26,"label":"G(c):|-:G(c)","rule":"Ax","forest":[{"ident":27,"label":"","rule":"","forest":[]}]}]}]},{"ident":19,"label":"F(a), G(c):|-: G(b), F(a)","rule":"WL","forest":[{"ident":20,"label":"F(a):|-:G(b), F(a)","rule":"WR","forest":[{"ident":22,"label":"F(a):|-:F(a)","rule":"Ax","forest":[{"ident":25,"label":"","rule":"","forest":[]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}]}
 |]

--- a/Carnap-Server/Handler/Review.hs
+++ b/Carnap-Server/Handler/Review.hs
@@ -259,10 +259,13 @@ renderProblem due uidAndData (Entity key val) = do
                 |]
                 where transtype = case lookup "transtype" (M.fromList opts) of Just s -> s; Nothing -> "prop"
                       formatContent c = case transtype of
-                                            "prop" -> maybe c id $ ndNotation `ofPropSys` sys <*> Just c
-                                            "first-order" -> maybe c id $ ndNotation `ofFOLSys` sys <*> Just c
-                                            "description" -> maybe c id $ ndNotation `ofDefiniteDescSys` sys <*> Just c
-                      problem = case lookup "problem" (M.fromList opts) of Just s -> s ++ " : " ++ (formatContent $ unpack goal)
+                                            "prop" -> fromMaybe c $ ndNotation `ofPropSys` sys <*> Just c
+                                            "first-order" -> fromMaybe c $ ndNotation `ofFOLSys` sys <*> Just c
+                                            "description" -> fromMaybe c $ ndNotation `ofDefiniteDescSys` sys <*> Just c
+                                            _ -> ""
+                      problem = case lookup "problem" (M.fromList opts) of
+                          Just s -> s ++ " : " ++ (formatContent $ unpack goal)
+                          Nothing -> ""
                       sys = case lookup "system" (M.fromList opts) of
                                 Just s -> s;
                                 Nothing -> if transtype == "prop" then "prop" else "firstOrder"
@@ -298,6 +301,7 @@ renderProblem due uidAndData (Entity key val) = do
                       content = case qualtype of
                                     "shortanswer"    -> unpack answer
                                     "multiplechoice" -> withChecked
+                                    _ -> ""
                       withChecked = case lookup "content" (M.fromList opts) of
                                         Nothing -> "Error no content"
                                         Just cnt -> unlines . map processEntry . lines . unpack $ cnt

--- a/Carnap-Server/Handler/Serve.hs
+++ b/Carnap-Server/Handler/Serve.hs
@@ -36,9 +36,9 @@ getServeR base components = do app <- getYesod
                       mjs <- retrievePandocVal (lookupMeta "js" meta)
                       defaultLayout $ do
                           addDocScripts
-                          maybe (pure [()]) (mapM (addScriptRemote))  mjs
+                          mapM_ addScriptRemote $ concat mjs
                           case mcss of
-                              Nothing -> mapM addStylesheet [StaticR css_bootstrapextra_css]
-                              Just ss -> mapM addStylesheetRemote ss
+                              Nothing -> addStylesheet $ StaticR css_bootstrapextra_css
+                              Just ss -> mapM_ addStylesheetRemote ss
                           $(widgetFile "document")
                           addScript $ StaticR ghcjs_allactions_runmain_js

--- a/Carnap-Server/Handler/User.hs
+++ b/Carnap-Server/Handler/User.hs
@@ -255,7 +255,7 @@ assignmentsOf accommodation course textbookproblems asmdex = do
           hidden = maybe False availabilityHidden . assignmentMetadataAvailability
           tooEarly t a | null (assignmentMetadataVisibleFrom a) = False
                        | otherwise = Just t < assignmentMetadataVisibleFrom a
-          tooLate t a _ | null (assignmentMetadataVisibleTill a) = False
+          tooLate _ a _ | null (assignmentMetadataVisibleTill a) = False
           tooLate t a Nothing = assignmentMetadataVisibleTill a < Just t
           tooLate t a (Just (Entity _ ex)) = (extensionUntil ex < t) && (assignmentMetadataVisibleTill a < Just t)
 

--- a/Carnap-Server/Util/Assignment.hs
+++ b/Carnap-Server/Util/Assignment.hs
@@ -1,16 +1,21 @@
 module Util.Assignment where
 
-import Import
-import Util.Database
-import System.Directory (doesFileExist)
+import           Import
+import           System.Directory (doesFileExist)
+import           Util.Database
 
-getAssignmentByCourse coursetitle title = do 
+getAssignmentByCourse
+    :: Text
+    -> Text
+    -> Handler (Entity AssignmentMetadata)
+getAssignmentByCourse coursetitle title = do
         mcourse <- runDB $ getBy $ UniqueCourse coursetitle
-        Entity cid course <- maybe (setMessage ("can't find a class with the title " ++ toHtml coursetitle) >> notFound) return mcourse 
+        Entity cid _course <- maybe (setMessage ("can't find a class with the title " ++ toHtml coursetitle) >> notFound) return mcourse
         masgn <- runDB (getBy $ UniqueAssignmentName title cid)
         aent <- maybe (setMessage ("can't find assignment with title  " ++ toHtml title) >> notFound) return masgn
         return aent
 
+getAssignmentAndPathByCourse :: Text -> Text -> Handler (Entity AssignmentMetadata, FilePath)
 getAssignmentAndPathByCourse coursetitle title = do
         aent@(Entity _ asgn) <- getAssignmentByCourse coursetitle title
         mdoc <- runDB (get $ assignmentMetadataDocument asgn)
@@ -25,5 +30,6 @@ getAssignmentAndPathByCourse coursetitle title = do
 
 -- | given an ident get the director in which assignments are stored for
 -- the instructor with that ident
+assignmentDir :: Text -> Handler FilePath
 assignmentDir ident = do master <- getYesod
                          return $ (appDataRoot $ appSettings master) </> "documents" </> unpack ident


### PR DESCRIPTION
There are still some left in Chapter, which will be obsolete soon, and
also with `writePandocTrusted` and similar where they are deprecated and
there is no clear replacement that does the same thing.

There should be no functional change from these refactors.