### PR TITLE
Update dependencies

### DIFF
--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -66,6 +66,7 @@ library
                      Util.API
                      Util.Data
                      Util.Grades
+                     Util.Sql
 
     if flag(dev) || flag(library-only)
         cpp-options:   -DDEVELOPMENT
@@ -110,6 +111,7 @@ library
                  , persistent                    >=2.8 && <2.14
                  , persistent-postgresql         >=2.8 && <2.14
                  , persistent-sqlite
+                 , esqueleto
                  , template-haskell
                  , th-utilities
                  , shakespeare                   >= 2.0        && < 2.1

--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -100,28 +100,27 @@ library
                  , yesod-auth-lti13
                  , lti13
                  , yesod-static                  >=1.6 && <1.7
-                 , yesod-form                    >=1.6 && <1.7
+                 , yesod-form                    >=1.6 && <1.8
                  , yesod-markdown                >= 0.12
                  , classy-prelude                >=1.4 && <1.6
                  , classy-prelude-conduit        >=1.4 && <1.6
                  , classy-prelude-yesod          >=1.4 && <1.6
                  , bytestring                    >=0.9 && <0.11
                  , text                          >=0.11 && <2.0
-                 , persistent                    >=2.8 && <2.12
-                 , persistent-postgresql         >=2.8 && <2.12
+                 , persistent                    >=2.8 && <2.14
+                 , persistent-postgresql         >=2.8 && <2.14
                  , persistent-sqlite
-                 , persistent-template           >= 2.5        && < 2.10
                  , template-haskell
                  , th-utilities
                  , shakespeare                   >= 2.0        && < 2.1
                  , monad-control                 >= 0.3        && < 1.1
-                 , wai-extra                     >= 3.0        && < 3.1
+                 , wai-extra                     >= 3.0        && < 3.2
                  , yaml                          >= 0.8        && < 0.12
                  , http-conduit                  >= 2.3        && < 2.4
                  , directory                     >= 1.1        && < 1.4
                  , warp                          >= 3.0        && < 3.4
                  , data-default
-                 , aeson                         >= 0.6        && < 1.5
+                 , aeson                         >= 0.6        && < 1.6
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4
                  , fast-logger                   >= 2.2        && < 3.1
@@ -151,8 +150,8 @@ library
                  , tz
                  , tzdata
                  , random
-                 , cryptonite >= 0.26 && < 0.27
-                 , base64-bytestring >= 1.0.0 && < 1.1
+                 , cryptonite >= 0.26 && < 0.30
+                 , base64-bytestring >= 1.0.0 && < 1.2
                  , clock
                  , wai-middleware-throttle >= 0.3.0.0 && < 0.4
                  , Carnap-Client

--- a/Carnap-Server/Handler/API/Instructor/Students.hs
+++ b/Carnap-Server/Handler/API/Instructor/Students.hs
@@ -6,7 +6,7 @@ import           Data.Time
 import           Data.Time.Zones
 import           Data.Time.Zones.All
 import           Import
-import           Util.Database       (problemQuery)
+import           Util.Sql
 import           Util.Handler
 
 getAPIInstructorStudentsR :: Text -> Text -> Handler Value
@@ -24,10 +24,8 @@ getAPIInstructorStudentR ident coursetitle udid = do
 getAPIInstructorStudentSubmissionsR :: Text -> Text -> UserDataId -> Handler Value
 getAPIInstructorStudentSubmissionsR ident coursetitle udid = do
              Entity cid _course <- canAccessClass ident coursetitle
-             subs <- runDB $ do asmd <- selectList [AssignmentMetadataCourse ==. cid] []
-                                ud <- studentEnrolled udid cid
-                                let pq = problemQuery (userDataUserId ud) (map entityKey asmd)
-                                selectList pq []
+             subs <- runDB $ do UserData {..} <- studentEnrolled udid cid
+                                problemsCompletedByUserIn userDataUserId cid
              returnJson (map entityVal subs)
 
 getAPIInstructorStudentExtensionsR :: Text -> Text -> UserDataId -> Handler Value

--- a/Carnap-Server/Handler/User.hs
+++ b/Carnap-Server/Handler/User.hs
@@ -12,6 +12,7 @@ import Data.Time.Zones
 import Data.Time.Zones.All
 import Util.Data
 import Util.Database
+import Util.Sql
 import Util.Grades
 import qualified Data.IntMap as IM
 import Data.IntMap ((!))
@@ -104,8 +105,7 @@ getUserR ident = do
                                accommodation <- getBy (UniqueAccommodation cid uid)
                                             >>= return . maybe 0 (accommodationDateExtraHours . entityVal)
                                extensions <- mapM (\asgn -> getBy $ UniqueExtension (entityKey asgn) uid) asmd 
-                               let pq = problemQuery uid (map entityKey asmd) 
-                               subs <- map entityVal <$> selectList pq []
+                               subs <- map entityVal <$> problemsCompletedByUserIn uid cid
                                return (asmd, extensions, accommodation, subs)
                     assignments <- assignmentsOf accommodation course textbookproblems (zip asmd extensions)
                     subtable <- problemsToTable course accommodation textbookproblems (zip asmd extensions) subs

--- a/Carnap-Server/Model.hs
+++ b/Carnap-Server/Model.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/Carnap-Server/Util/Database.hs
+++ b/Carnap-Server/Util/Database.hs
@@ -223,18 +223,3 @@ udByInstructorId id = do l <- runDB $ selectList [UserDataInstructorId ==. Just 
                                    [] -> error $ "couldn't find any user data for instructor " ++ show id
                                    _ -> error $ "Multiple user data for instructor " ++ show id
 
-getProblemQuery
-    :: PersistentSite site
-    => Key User
-    -> Key Course
-    -> HandlerFor site [Filter ProblemSubmission]
-getProblemQuery uid cid = do asl <- runDB $ map entityKey <$> selectList [AssignmentMetadataCourse ==. cid] []
-                             return $ problemQuery uid asl
-
-problemQuery
-    :: Key User
-    -> [Key AssignmentMetadata]
-    -> [Filter ProblemSubmission]
-problemQuery uid asl = [ProblemSubmissionUserId ==. uid]
-                    ++ ([ProblemSubmissionSource ==. Book] ||. [ProblemSubmissionAssignmentId <-. assignmentList])
-        where assignmentList = map Just asl

--- a/Carnap-Server/Util/Grades.hs
+++ b/Carnap-Server/Util/Grades.hs
@@ -8,6 +8,7 @@ import           Import
 import           Text.Read     (read)
 import           Util.Data
 import           Util.Database
+import           Util.Sql
 
 --This is probably marginally more efficient when you have problems but not
 --a list of assignments
@@ -83,8 +84,7 @@ scoreByIdAndClassTotal cid uid =
 
 scoreByIdAndClassPerProblem :: Key Course -> Key User -> HandlerFor App [(Either (Key AssignmentMetadata) Text, Int, Text)]
 scoreByIdAndClassPerProblem cid uid =
-        do pq <- getProblemQuery uid cid
-           subs <- map entityVal <$> (runDB $ selectList pq [])
+        do subs <- map entityVal <$> runDB (problemsCompletedByUserIn uid cid)
            textbookproblems <- getProblemSets cid
            accommodation <- (runDB $ getBy $ UniqueAccommodation cid uid)
                         >>= return . maybe 0 (accommodationDateExtraHours . entityVal)

--- a/Carnap-Server/Util/Sql.hs
+++ b/Carnap-Server/Util/Sql.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Util.Sql where
+
+import Carnap.GHCJS.SharedTypes (ProblemSource (Book))
+import ClassyPrelude hiding (on)
+import Database.Esqueleto.Experimental
+import Model
+
+-- NOTE: probably should use a newer esqueleto with the type level strings e.g. ps ^. #assignmentId
+-- but I don't have time to port the codebase re other updates
+
+problemsCompletedByUserIn ::
+    MonadIO m =>
+    UserId ->
+    CourseId ->
+    SqlPersistT m [Entity ProblemSubmission]
+problemsCompletedByUserIn uid cid = do
+    select $ do
+        (ps :& amd) <-
+            from $
+                table @ProblemSubmission
+                    -- also include problem submissions not attached to an assignment ie book ones
+                    `leftJoin` table @AssignmentMetadata
+                    `on` (\(ps :& amd) -> ps ^. ProblemSubmissionAssignmentId ==. amd ?. AssignmentMetadataId)
+        where_ $
+            ps ^. ProblemSubmissionUserId ==. val uid
+                &&. (amd ?. AssignmentMetadataCourse ==. val (Just cid) ||. ps ^. ProblemSubmissionSource ==. val Book)
+        pure ps

--- a/default.nix
+++ b/default.nix
@@ -50,18 +50,23 @@ let
 
   inherit (nixpkgs) lib;
 
-  devtools = { isGhcjs }: with nixpkgs.haskell.packages."${ghcVer}"; ([
+  devtools = { isGhcjs }:
+  let
+    modernpkgs = nixpkgs.haskell.packages."${ghcVer}";
+    pkgs = if isGhcjs then nixpkgs-stable.haskell.packages.ghc865 else modernpkgs;
+  in with pkgs; ([
     Cabal
     cabal-install
     ghcid
-    hasktags
-    yesod-bin
     # hls is disabled for ghcjs shells because it probably will not work on
     # pure-ghcjs components.
-  ] ++ (lib.optional (hls && !isGhcjs) haskell-language-server)
+  ] ++ (lib.optionals (hls && !isGhcjs) [haskell-language-server])
   ) ++ (with nixpkgs; [
     cabal2nix
     niv
+  ]) ++ (with modernpkgs; [
+    yesod-bin
+    hasktags
   ]);
 
   in rec {

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { ghcjsVer ? "ghcjs",
-  ghcVer ? "ghc884",
+  ghcVer ? "ghc8106",
   profiling ? false,
   hls ? false,
   inNixShell ? false,

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "nixpkgs-unstable",
+        "branch": "haskell-updates",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca3fa9c32a45f028f480ab8ec26cc4bd8ce800ad",
-        "sha256": "06brxwypbsp1y2m9ppprkwsjg60jjp6bs2mmx7s8imk32pw86vi9",
+        "rev": "3440070b83ffdf2ecd787dfc5542374e9ad06ec0",
+        "sha256": "1nycrgv24qarv2vxy35jpyxd1ji7v3ndblpb655f31zhnq8syl93",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ca3fa9c32a45f028f480ab8ec26cc4bd8ce800ad.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/3440070b83ffdf2ecd787dfc5542374e9ad06ec0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-stable": {

--- a/server.nix
+++ b/server.nix
@@ -12,52 +12,29 @@ let
     overrideCabal;
 in
 newpkgs: oldpkgs: {
-  # TODO: This has actually been fixed as of 2021-01-09 but it probably hasn't
-  # got into our nixpkgs. Need to update that.
-  # downgrade to 1.8.x because yesod-auth-oauth2 has not fixed support for
-  # newer versions in any *released* version yet
-  hoauth2 = oldpkgs.callHackage "hoauth2" "1.8.9" { };
-
-  # update to fix a possible security bug: https://github.com/thoughtbot/yesod-auth-oauth2/issues/132
-  yesod-auth-oauth2 = oldpkgs.callHackageDirect {
-    pkg = "yesod-auth-oauth2";
-    ver = "0.6.1.3";
-    sha256 = "1bikn9kfw6mrsais4z1nk07aa7i7hyrcs411kbbfgc7n74k6sd5b";
-  } { };
-
   # failing tests on macOS for some reason:
   # https://github.com/ubc-carnap-team/Carnap/runs/1074093219?check_suite_focus=true
   tz = dontCheck oldpkgs.tz;
-
-  # Use the version from https://github.com/yesodweb/persistent/pull/1106
-  # using overrideSrc to maintain dependency relations and nix's fixes/overrides for these
-  persistent = overrideSrc oldpkgs.persistent { src = (persistent + "/persistent"); };
-  persistent-sqlite = overrideSrc oldpkgs.persistent-sqlite { src = (persistent + "/persistent-sqlite"); };
-  # this one we have to recreate from scratch anyway because they added a dependency
-  persistent-postgresql = dontCheck (oldpkgs.callCabal2nix "persistent-postgresql" (persistent + "/persistent-postgresql") { });
-  persistent-template = overrideSrc oldpkgs.persistent-template { src = (persistent + "/persistent-template"); };
-  persistent-qq = overrideSrc oldpkgs.persistent-qq { src = (persistent + "/persistent-qq"); };
-  persistent-test = overrideSrc oldpkgs.persistent-test { src = (persistent + "/persistent-test"); };
-  # too tight an upper version bound on persistent
-  yesod-persistent = doJailbreak oldpkgs.yesod-persistent;
-  yesod-auth = doJailbreak oldpkgs.yesod-auth;
 
   # they wrote a spec that calls out to Google. It does not work in a nix
   # builder.
   oidc-client = dontCheck oldpkgs.oidc-client;
 
-  # lti13 and yesod-auth-lti13 are not in nixpkgs yet
+  # lti13 and yesod-auth-lti13 are not in all-hashes yet, 99% of the time, so
+  # just manually pull them...
+  #
+  # Development overrides:
   # lti13 = oldpkgs.callCabal2nix "lti13" ../lti13/lti13 { };
   # yesod-auth-lti13 = oldpkgs.callCabal2nix "yesod-auth-lti13" ../lti13/yesod-auth-lti13 { };
   lti13 = oldpkgs.callHackageDirect {
     pkg = "lti13";
-    ver = "0.2.0.2";
-    sha256 = "014pmhl28z242pmmkn63sh7ijdjlh2f7fbq8l5bc0q6llcd6if7y";
+    ver = "0.2.0.3";
+    sha256 = "0hwsrag4skck992hnzmj5n5iclbbrbwdwa5rxsrks8ins7jgrg1f";
   } { };
   yesod-auth-lti13 = oldpkgs.callHackageDirect {
     pkg = "yesod-auth-lti13";
-    ver = "0.2.0.2";
-    sha256 = "0q2vy7zdv5sm09wh2cqslgz0yh8l4h2gd7w1024i2mgblxa8v4xw";
+    ver = "0.2.0.3";
+    sha256 = "0mmhznyzjaqmbcgvcznab2sx5ghaxv66cxq07b8yimg61yfadbgb";
   } { };
 
   # dontCheck: https://github.com/gleachkr/Carnap/issues/123

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,38 +1,22 @@
 flags: {}
 extra-package-dbs: []
 extra-deps:
-    - yesod-markdown-0.12.6.3
-    - yesod-auth-oauth2-0.6.1.3
-    - hoauth2-1.8.9
-    # - uri-bytestring-aeson-0.1.0.8
-    - diagrams-builder-0.8.0.5
-    - tz-0.1.3.4@sha256:bd311e202b8bdd15bcd6a4ca182e69794949d3b3b9f4aa835e9ccff011284979,5086
-    - th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869
-    - haskell-src-exts-simple-1.22.0.0
-    - haskell-src-exts-1.22.0
+    - yesod-markdown-0.12.6.11
+    - yesod-auth-oauth2-0.6.3.4
+    - hoauth2-1.16.0
+    - tz-0.1.3.5
+    - th-utilities-0.2.4.3
+    - haskell-src-exts-simple-1.23.0.0
+    - haskell-src-exts-1.23.1
     - wai-middleware-throttle-0.3.0.1@sha256:8da81c156abbcaee3bdda60763bb9780ae1b9ff447bd5580202c0e0f5f8f7bcb,2522
-    - token-bucket-0.1.0.1@sha256:ef80a31e7f4f794e3686eb405a49afc663535dd3a11c012a002a7bacce897da6,1912
-    - git: https://github.com/yesodweb/persistent.git
-      commit: 1cdadc10405e9e3b1e0e73e2c1d6ec84eed69a53
-      subdirs:
-          - persistent
-          - persistent-sqlite
-          - persistent-postgresql
-          - persistent-template
-          - persistent-qq
-    - lti13-0.2.0.2
-    - yesod-auth-lti13-0.2.0.2
-    - oidc-client-0.5.1.0
-
-# :( persistent bug fix requires a git version, which means we have to turn off
-# version checking in every yesod project
-allow-newer: true
+    - token-bucket-0.1.0.1
+    - lti13-0.2.0.3
+    - yesod-auth-lti13-0.2.0.3
+    - oidc-client-0.6.0.0
+    - classy-prelude-yesod-1.5.0
 
 packages:
 - Carnap/
 - Carnap-Server/
 - Carnap-Client/
-#resolver: lts-6.25
-#resolver: lts-12.26
-#resolver: lts-14.27
-resolver: lts-16.11
+resolver: lts-18.7


### PR DESCRIPTION
Also workaround persistent not properly disabling foreign keys while
migrating sqlite databases, so sqlite migrations will actually work
properly instead of doing foreign key errors!!

~~This is probably not currently mergeable because it is not possible to get a stackage LTS with ghc 8.8.4 and new enough `persistent` (min 2.12.x to allow dropping persistent-template which was absorbed then), and we had issues with GHC 8.10, and 8.10.5 that might fix those issues is not out yet :/~~

~~It builds and runs fine with Nix and ghc-8.8.4 though (well, after a very long time of building every dependency under the sun because the default ghc got moved to 8.10).~~

~~Another of these PRs. Sorry...~~

Good to go!!