### PR TITLE
CSS improvements

### DIFF
--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -45,18 +45,19 @@ library
                      Handler.API.Instructor.Students
                      Handler.API.Instructor.Assignments
                      Handler.API.Instructor.Courses
-                     Filter.RenderFormulas
-                     Filter.Randomize
-                     Filter.Sidenotes
-                     Filter.TreeDeduction
-                     Filter.Sequent
-                     Filter.SynCheckers
+                     Filter.Anchors
+                     Filter.CounterModelers
                      Filter.ProofCheckers
+                     Filter.Qualitative
+                     Filter.Randomize
+                     Filter.RenderFormulas
+                     Filter.Sequent
+                     Filter.Sidenotes
+                     Filter.SynCheckers
                      Filter.Translate
+                     Filter.TreeDeduction
                      Filter.TruthTables
                      Filter.TruthTrees
-                     Filter.CounterModelers
-                     Filter.Qualitative
                      Filter.Util
                      Util.Handler
                      Util.Assignment

--- a/Carnap-Server/Filter/Anchors.hs
+++ b/Carnap-Server/Filter/Anchors.hs
@@ -1,0 +1,15 @@
+module Filter.Anchors where
+
+import Import
+import Text.Pandoc (Inline(..), Block(..))
+
+-- some code is from https://github.com/jgm/pandoc-website/issues/49
+
+makeAnchors :: Block -> Block
+makeAnchors (Header level meta@(identifier, _classes, _kvps) inlines)
+            | not . null $ identifier =
+    Header level meta inlines'
+    where
+        link = Link ("", ["anchor":: Text], [("aria-hidden", "true")]) [] ("#" <> identifier, "heading anchor link")
+        inlines' = link:inlines
+makeAnchors x = x

--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -108,6 +108,11 @@ instance Yesod App where
         mdoc <- maybeUserTextbookDoc
         let isInstructor = not $ null (mud >>= userDataInstructorId . entityVal)
         pc <- widgetToPageContent $ do
+            -- HACK: This is here to force the encoding declaration to be at
+            -- the very top of the Cassius generated stylesheets, hopefully no
+            -- matter what the other pages look like.
+            toWidget $ CssBuilder "@charset \"UTF-8\";\n"
+
             addStylesheet $ StaticR css_bootstrap_css
             addStylesheet $ StaticR css_font_awesome_css
             $(widgetFile "default-layout")

--- a/Carnap-Server/Util/Handler.hs
+++ b/Carnap-Server/Util/Handler.hs
@@ -22,6 +22,7 @@ import           Util.Database
 import           Yesod.Core.Types       (GWData (..), tellWidget)
 import           Yesod.Markdown
 
+import           Filter.Anchors
 import           Filter.CounterModelers
 import           Filter.ProofCheckers
 import           Filter.Qualitative
@@ -88,6 +89,7 @@ allFilters = makeTreeDeduction
              . makeTreeDeduction
              . makeTruthTables
              . makeTruthTrees
+             . makeAnchors
              . renderFormulas
 
 retrievePandocVal :: MonadHandler m => Maybe MetaValue -> m (Maybe [Text])

--- a/Carnap-Server/static/css/bootstrapextra.css
+++ b/Carnap-Server/static/css/bootstrapextra.css
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 ol.example > li {
     list-style: none;
     position: relative;
@@ -38,4 +40,25 @@ details {
     border-radius: 4px;
     padding: .75em 1em .75em;
     margin-bottom: 1.5em;
+}
+
+/* This was adapted from the pandoc website source:
+ * https://github.com/jgm/pandoc-website/blob/master/css/screen.css#L108-L132 */
+.anchor::before {
+    content: '🔗\FE0E';
+    display: inline-block;
+    left: -0.75em;
+    font-size: calc(min(1.1rem, 66%));
+    line-height: calc(min(1.1rem, 66%) * 3.3);
+    opacity: 0.2;
+    position: absolute;
+}
+
+h1:hover > .anchor::before,
+h2:hover > .anchor::before,
+h3:hover > .anchor::before,
+h4:hover > .anchor::before,
+h5:hover > .anchor::before,
+h6:hover > .anchor::before {
+    opacity: 1;
 }

--- a/Carnap-Server/static/css/bootstrapextra.css
+++ b/Carnap-Server/static/css/bootstrapextra.css
@@ -26,3 +26,16 @@ img {
     /* Don't let images overflow their container */
     max-width: 100%;
 }
+
+/* nice box around the details dropdowns, bold text */
+details summary {
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+details {
+    border: 1px solid #aaa;
+    border-radius: 4px;
+    padding: .75em 1em .75em;
+    margin-bottom: 1.5em;
+}

--- a/Carnap-Server/templates/default-layout.cassius
+++ b/Carnap-Server/templates/default-layout.cassius
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 @font-face
     font-family:street
     src:url("@{StaticR fonts_Streetvertising_ttf}")

--- a/Carnap-Server/templates/document.cassius
+++ b/Carnap-Server/templates/document.cassius
@@ -1,6 +1,5 @@
-#main 
-    p, ol, dl, ul, blockquote
-        max-width:650pt
+.container
+    max-width: 650pt
 
 .exercise
     margin-bottom:20px


### PR DESCRIPTION

I put some boxes around `<summary>` tags so they're easier to use.

These were hard to distinguish from the rest of the page and overall
kind of hard to see. They now have a border and the titles are easier to
see.

I also attempted to fix that mojibake issue on the user menu arrow. It seems to be emitting it at the top of the stylesheet as intended in the pages I've looked at.

Screenshots:

![Screenshot_20210819_034110](https://user-images.githubusercontent.com/6652840/130056968-fcc67a7f-da9c-44d0-9738-412e0d9f7cb1.png)
![image](https://user-images.githubusercontent.com/6652840/130057020-dfef99da-d7e3-40bf-9ab9-8163be963528.png)
