### PR TITLE
User aliases for documents

### DIFF
--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -74,24 +74,26 @@ library
     else
         ghc-options:   -Wall -fwarn-tabs -O2 -dth-dec-file -Wno-name-shadowing
 
-    extensions: TemplateHaskell
-                QuasiQuotes
-                OverloadedStrings
-                NoImplicitPrelude
-                MultiParamTypeClasses
-                TypeFamilies
-                GADTs
-                GeneralizedNewtypeDeriving
+    extensions: DeriveDataTypeable
+                EmptyDataDecls
                 FlexibleContexts
                 FlexibleInstances
-                EmptyDataDecls
+                GADTs
+                GeneralizedNewtypeDeriving
                 LambdaCase
+                MultiParamTypeClasses
+                NamedFieldPuns
+                NoImplicitPrelude
                 NoMonomorphismRestriction
+                OverloadedStrings
+                PatternGuards
+                QuasiQuotes
                 RankNTypes
-                DeriveDataTypeable
-                ViewPatterns
-                TupleSections
                 RecordWildCards
+                TemplateHaskell
+                TupleSections
+                TypeFamilies
+                ViewPatterns
 
     build-depends: base >=4.8.2.0 && <4.9 || >=4.9.1.0 && <5
                  , yesod                         >=1.6 && <1.7

--- a/Carnap-Server/Model.hs
+++ b/Carnap-Server/Model.hs
@@ -21,7 +21,13 @@ import Carnap.GHCJS.SharedTypes(ProblemSource(..),ProblemType(..),ProblemData(..
 -- http://www.yesodweb.com/book/persistent/
 
 share [mkPersist sqlSettings, mkDeleteCascade sqlSettings, mkMigrate "migrateAll"]
-    $(persistFileWith lowerCaseSettings =<< (pathRelativeToCabalPackage "config/models"))
+    $(persistFileWith lowerCaseSettings =<< pathRelativeToCabalPackage "config/models")
+
+-- This is written like this to allow for support for targeting groups, if
+-- these are added as a feature in the future
+data AliasTargetTy = TargetInstructor UserId
+    deriving (Show, Read, Eq)
+derivePersistField "AliasTargetTy"
 
 --we put these in because the template haskell chokes on the keyword "data"
 --as the name of a field

--- a/Carnap-Server/Util/Data.hs
+++ b/Carnap-Server/Util/Data.hs
@@ -11,8 +11,10 @@ import           Carnap.Languages.PureFirstOrder.Syntax    (PureFOLForm)
 import           Carnap.Languages.PurePropositional.Syntax (PureForm)
 import           ClassyPrelude.Yesod
 import           Data.Aeson                                (decode, encode)
+import qualified Data.Char                                 as C
 import qualified Data.IntMap                               as IM (fromList)
 import qualified Data.Map                                  as M
+import qualified Data.Text                                 as T
 import qualified Data.Text.Lazy                            as LT
 import           Data.Time
 import           Text.HTML.TagSoup
@@ -47,6 +49,16 @@ derivePersistField "SharingScope"
 data APIKeyScope = APIKeyScopeRoot
     deriving (Show, Read, Eq)
 derivePersistField "APIKeyScope"
+
+-- FIXME: it's sad that this is not a newtype; I couldn't figure out how to
+-- derive the appropriate things to use it as a primary key.
+makeDocumentUserAlias :: Text -> Maybe Text
+makeDocumentUserAlias alias | aliasIsOk alias = Just alias
+    where
+    aliasIsOk = T.foldl' aliasCharIsOk True
+    aliasCharIsOk True c = C.isAscii c && (C.isAlphaNum c || c `elem` ("-_" :: String))
+    aliasCharIsOk False _ = False
+makeDocumentUserAlias _ = Nothing
 
 data AvailabilityStatus = ViaPassword Text
                         | HiddenViaPassword Text

--- a/Carnap-Server/config/models
+++ b/Carnap-Server/config/models
@@ -182,6 +182,17 @@ Tag
     UniqueTag bearer name
     deriving Eq
 
+-- Alias for the /shared/:identifier route
+Alias
+    target AliasTargetTy
+    -- | Validate this with @makeDocumentUserAlias@ in @Util.Data@.
+    name Text
+    -- Each entity can have one alias at most
+    UniqueAliasTarget target
+    -- Each alias must be unique. Aliases are of a format that prevents their
+    -- overlap with regular idents
+    Primary name
+
 -- the below `deriving Show` is load-bearing: it mitigates
 -- https://github.com/yesodweb/persistent/issues/1047
 InstructorMetadata

--- a/Carnap-Server/templates/instructor.hamlet
+++ b/Carnap-Server/templates/instructor.hamlet
@@ -145,7 +145,7 @@
                                 $forall Entity k a <- documents
                                     <tr id="document-#{documentFilename a}">
                                         <td>
-                                            <a href="@{DocumentR ident (documentFilename a)}">
+                                            <a href="@{DocumentR identForDocumentsRLinks (documentFilename a)}">
                                                 #{documentFilename a}
                                         <td> #{formatTime defaultTimeLocale "%F" $ documentDate a}
                                         <td> #{show $ documentScope a}
@@ -168,6 +168,12 @@
                     <form method=post enctype=#{enctypeCreateAPIKey}>
                         ^{createAPIKeyWidget}
                         <input.btn.btn-primary  type=submit value="Create New Key">
+                    <hr>
+                    <h3>User Alias
+                    <p>Set an alias that can be used in place of your email in document links.
+                    <form method=post enctype=#{enctypeSetUserAlias}>
+                        ^{setUserAliasWidget}
+                        <input.btn.btn-primary type=submit value="Set Alias">
                 <div.tab-pane id="manageCourse" role="tabpanel">
                     <h2>Create Course
                     <form method=post enctype=#{enctypeCreateCourse}>


### PR DESCRIPTION
This is based on #283 because I couldn't resist the better dev tools. Please give that one some time to test especially with the term starting up. Worst case, if we get messed up by compiler bugs again, I can rebase this onto master.

What this does is change the links like http://localhost:3000/shared/someone@example.com/chapter13.pandoc to http://localhost:3000/shared/jade/chapter13.pandoc.

![image](https://user-images.githubusercontent.com/6652840/131298972-9062ce5c-8409-4a5c-9e0d-921e5006d0bb.png)

(the API key is from my local test instance, I just revoked it, not that it compromises anything anyway)