### PR TITLE
Configurable book link everywhere

### DIFF
--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -3,7 +3,6 @@ module Foundation where
 import qualified Control.Monad.Trans.Except as E
 import qualified Data.CaseInsensitive       as CI
 import qualified Data.HashMap.Strict        as HM
-import qualified Data.Map                   as Map
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as TE
 import qualified Data.Text.Encoding.Error   as TEE
@@ -110,6 +109,7 @@ instance Yesod App where
         mud <- maybeUserData
         mcourse <- maybeUserCourse
         mdoc <- maybeUserTextbookDoc
+        bookRoute <- runDB getBookLink
         let isInstructor = not $ null (mud >>= userDataInstructorId . entityVal)
         pc <- widgetToPageContent $ do
             -- HACK: This is here to force the encoding declaration to be at
@@ -339,6 +339,9 @@ instance Yesod App where
 
     errorHandler other = defaultErrorHandler other
 
+instance BookyYesod App where
+    bookRoute = BookR
+
 instance YesodJquery App where
         urlJqueryJs _ = Right "https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"
         urlJqueryUiJs _ = Right "https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"
@@ -489,6 +492,7 @@ instance YesodAuth App where
     authLayout widget = liftHandler $ do
         master <- getYesod
         mmsg <- getMessage
+        bookRoute <- runDB getBookLink
         pc <- widgetToPageContent $ do
             addStylesheet $ StaticR css_bootstrap_css
             $(widgetFile "auth-layout")

--- a/Carnap-Server/Handler/Chapter.hs
+++ b/Carnap-Server/Handler/Chapter.hs
@@ -103,6 +103,8 @@ chapterLayout widget = do
         mud <- maybeUserData
         mcourse <- maybeUserCourse
         mdoc <- maybeUserTextbookDoc
+        -- we're the book ;-)
+        let bookRoute = BookR
         let isInstructor = not $ null (mud >>= userDataInstructorId . entityVal)
         pc <- widgetToPageContent $ do
             toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/command.julius")

--- a/Carnap-Server/Handler/Rule.hs
+++ b/Carnap-Server/Handler/Rule.hs
@@ -13,6 +13,7 @@ import           TH.RelativePaths            (pathRelativeToCabalPackage)
 
 import           Util.Database
 import           Util.Handler                (addDocScripts)
+import Settings.Runtime (getBookLink)
 
 getRuleR :: Handler Html
 getRuleR = do derivedPropRules <- getPropDrList
@@ -88,6 +89,7 @@ ruleLayout widget = do
         mud <- maybeUserData
         mcourse <- maybeUserCourse
         mdoc <- maybeUserTextbookDoc
+        bookRoute <- runDB getBookLink
         let isInstructor = not $ null (mud >>= userDataInstructorId . entityVal)
         pc <- widgetToPageContent $ do
             toWidgetHead $(juliusFile =<< pathRelativeToCabalPackage "templates/command.julius")

--- a/Carnap-Server/Settings/Runtime.hs
+++ b/Carnap-Server/Settings/Runtime.hs
@@ -1,23 +1,26 @@
 module Settings.Runtime (
     module Settings.RuntimeDefs,
+    BookyYesod(..),
     getDisableGoogleReg,
     getInstanceAdminEmail,
+    getBookLink,
     setRtSetting,
-    getRtSettings
+    getRtSettings,
 ) where
 
 import           Control.Monad.Trans.Maybe (MaybeT (..))
+import qualified Data.Text                 as T
 import           Import.NoFoundation
 import           Settings.RuntimeDefs
 
 getSettingRaw :: PersistentSite site => RTSetType -> MaybeT (YesodDB site) Value
 getSettingRaw ty =
     runtimeSettingValue . entityVal
-        <$> (MaybeT $ getBy (UniqueSetting ty))
+        <$> MaybeT (getBy (UniqueSetting ty))
 
 getSetting :: PersistentSite site => RTSetType -> MaybeT (YesodDB site) RTSetting
 getSetting ty = do
-    set <- getSettingRaw $ ty
+    set <- getSettingRaw ty
     MaybeT . return $ parseRTSetting ty set
 
 setRtSetting :: PersistentSite site => RTSetting -> YesodDB site ()
@@ -26,15 +29,20 @@ setRtSetting set = do
     _ <- upsert (RuntimeSetting (rtSettingType set) ser) [RuntimeSettingValue =. ser]
     return ()
 
-getRtSettings :: PersistentSite site => YesodDB site [RTSetting]
+getRtSettings :: (PersistentSite site, BookyYesod site) => YesodDB site [RTSetting]
 getRtSettings = do
     sequence
         [ DisableGoogleReg <$> getDisableGoogleReg
         , InstanceAdminEmail <$> getInstanceAdminEmail
+        , CustomBookLink . renderBookLink <$> getBookLink
         ]
+    where
+    renderBookLink link =
+        let (segs, _params) = renderRoute link
+        in T.intercalate "/" segs
 
 withDefault :: Functor f => a -> MaybeT f a -> f a
-withDefault def comp = fromMaybe def <$> (runMaybeT comp)
+withDefault def comp = fromMaybe def <$> runMaybeT comp
 
 getDisableGoogleReg :: PersistentSite site => YesodDB site Bool
 getDisableGoogleReg = withDefault False $ do
@@ -45,3 +53,19 @@ getInstanceAdminEmail :: PersistentSite site => YesodDB site Text
 getInstanceAdminEmail = withDefault "gleachkr@gmail.com" $ do
     InstanceAdminEmail v <- getSetting TyInstanceAdminEmail
     return v
+
+-- | A Yesod with a @BookR@, of course!
+class (Yesod site, ParseRoute site) => BookyYesod site where
+    bookRoute :: Route site
+
+getBookLink :: (PersistentSite site, BookyYesod site) => YesodDB site (Route site)
+getBookLink = withDefault bookRoute $ do
+    CustomBookLink v <- getSetting TyCustomBookLink
+    yesod <- lift getYesod
+    cleaned <- MaybeT
+        $ case cleanPath yesod (T.splitOn "/" v) of
+            Right clean -> return . Just $ clean
+            Left unclean      -> do
+                $logWarn ("Bad book link, becomes " <> (T.pack . show $ unclean))
+                return Nothing
+    MaybeT . return $ parseRoute (cleaned, [])

--- a/Carnap-Server/Settings/RuntimeDefs.hs
+++ b/Carnap-Server/Settings/RuntimeDefs.hs
@@ -11,16 +11,20 @@ data RTSetType =
     -- ^ disable new registrations of accounts with the Google login back end
     | TyInstanceAdminEmail
     -- ^ the email for the administrator of this Carnap instance
+    | TyCustomBookLink
+    -- ^ custom document based book url that's used for non logged in users
     deriving (Show, Read, Eq, Enum)
 
 data RTSetting =
       DisableGoogleReg Bool
     | InstanceAdminEmail Text
+    | CustomBookLink Text
     deriving (Show, Eq)
 
 rtSettingType :: RTSetting -> RTSetType
 rtSettingType (DisableGoogleReg _) = TyDisableGoogleReg
 rtSettingType (InstanceAdminEmail _) = TyInstanceAdminEmail
+rtSettingType (CustomBookLink _) = TyCustomBookLink
 
 handleResult :: Result a -> Maybe a
 handleResult (Error _) = Nothing
@@ -31,13 +35,17 @@ parseRTSetting TyDisableGoogleReg val =
     DisableGoogleReg <$> handleResult (fromJSON val)
 parseRTSetting TyInstanceAdminEmail val =
     InstanceAdminEmail <$> handleResult (fromJSON val)
+parseRTSetting TyCustomBookLink val =
+    CustomBookLink <$> handleResult (fromJSON val)
 
 serializeRTSetting :: RTSetting -> Value
 serializeRTSetting (DisableGoogleReg b) = toJSON b
 serializeRTSetting (InstanceAdminEmail b) = toJSON b
+serializeRTSetting (CustomBookLink l) = toJSON l
 
 displayRTSetType :: RTSetType -> Text
 displayRTSetType TyDisableGoogleReg = "Disable Google Registration"
 displayRTSetType TyInstanceAdminEmail = "Administrator Email"
+displayRTSetType TyCustomBookLink = "Custom Book Path (e.g. \"shared/someone@example.com/somedoc.pandoc\")"
 
 derivePersistField "RTSetType"

--- a/Carnap-Server/Util/Handler.hs
+++ b/Carnap-Server/Util/Handler.hs
@@ -6,17 +6,17 @@ import           Import
 import           System.Directory       (createDirectoryIfMissing,
                                          doesFileExist, removeFile)
 import           System.FilePath
+import           TH.RelativePaths       (pathRelativeToCabalPackage)
 import           Text.Blaze.XHtml5      (Markup, ToMarkup)
 import           Text.Hamlet            (hamletFile)
 import           Text.Julius            (juliusFile)
-import           Text.Pandoc            (Inline (..), Meta, MetaValue (..),
-                                         Pandoc (..), PandocError,
-                                         WrapOption (..), WriterOptions (..),
-                                         compileTemplate, getTemplate,
-                                         lookupMeta, readerExtensions, runIO)
-import           Text.Pandoc            (Block)
+import           Text.Pandoc            (Block, Inline (..), Meta,
+                                         MetaValue (..), Pandoc (..),
+                                         PandocError, WrapOption (..),
+                                         WriterOptions (..), compileTemplate,
+                                         getTemplate, lookupMeta,
+                                         readerExtensions, runIO)
 import           Text.Pandoc.Walk       (Walkable, walk)
-import           TH.RelativePaths       (pathRelativeToCabalPackage)
 import           Util.Data
 import           Util.Database
 import           Yesod.Core.Types       (GWData (..), tellWidget)
@@ -33,6 +33,7 @@ import           Filter.Translate
 import           Filter.TreeDeduction
 import           Filter.TruthTables
 import           Filter.TruthTrees
+import           Settings.Runtime       (getBookLink)
 
 minimalLayout :: ToMarkup a => a -> WidgetFor site ()
 minimalLayout c = [whamlet|
@@ -43,15 +44,16 @@ minimalLayout c = [whamlet|
 
 cleanLayout :: ToWidget App a => a -> HandlerFor App Markup
 cleanLayout widget = do
-        master <- getYesod
-        mmsg <- getMessage
-        authmaybe <- maybeAuth
-        mud <- maybeUserData
-        mcourse <- maybeUserCourse
-        mdoc <- maybeUserTextbookDoc
-        let isInstructor = not $ null (mud >>= userDataInstructorId . entityVal)
-        pc <- widgetToPageContent $(widgetFile "default-layout")
-        withUrlRenderer $(hamletFile =<< pathRelativeToCabalPackage "templates/default-layout-wrapper.hamlet")
+    master <- getYesod
+    mmsg <- getMessage
+    authmaybe <- maybeAuth
+    mud <- maybeUserData
+    mcourse <- maybeUserCourse
+    mdoc <- maybeUserTextbookDoc
+    bookRoute <- runDB getBookLink
+    let isInstructor = not $ null (mud >>= userDataInstructorId . entityVal)
+    pc <- widgetToPageContent $(widgetFile "default-layout")
+    withUrlRenderer $(hamletFile =<< pathRelativeToCabalPackage "templates/default-layout-wrapper.hamlet")
 
 addDocScripts :: (MonadWidget m, HandlerSite m ~ App) => m ()
 addDocScripts = do

--- a/Carnap-Server/templates/auth-layout.hamlet
+++ b/Carnap-Server/templates/auth-layout.hamlet
@@ -9,7 +9,7 @@
                     <a href=@{InfoR}>
                         _{MsgLayoutAbout}
                 <li>
-                    <a href=@{BookR}>
+                    <a href=@{bookRoute}>
                         _{MsgLayoutBook}
 
 <div id="main" role="main">

--- a/Carnap-Server/templates/default-layout.hamlet
+++ b/Carnap-Server/templates/default-layout.hamlet
@@ -13,10 +13,10 @@
                             <a href=@{CourseAssignmentR (courseTitle course) (documentFilename doc)}>
                                 _{MsgLayoutBook}
                         $nothing
-                            <a href=@{BookR}>
+                            <a href=@{bookRoute}>
                                 _{MsgLayoutBook}
                     $nothing
-                        <a href=@{BookR}>_{MsgLayoutBook}
+                        <a href=@{bookRoute}>_{MsgLayoutBook}
                 $maybe (Entity _ user) <- authmaybe
                     <li.dropdown>
                             $maybe Entity _ userdata <- mud


### PR DESCRIPTION
This PR is also based on #283, so I suggest we make sure that one's ok before merging this.

This is all we need to kill the special book route, but we probably should not do that until after next term to not cause anyone too much pain.

This is actually really interesting: I use Yesod's URL parser to
validate the link is going to a plausible page so we don't lose any
type safety in our URL handling!

![image](https://user-images.githubusercontent.com/6652840/131313080-b249641f-58bc-4ed0-8cc3-b8c95fca7acb.png)
