### PR TITLE
Support tags in the API

### DIFF
--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -41,6 +41,8 @@ library
                      Handler.Document
                      Handler.Serve
                      Handler.API.API
+                     Handler.API.AesonHelper
+                     Handler.API.Instructor.Types
                      Handler.API.Instructor.Documents
                      Handler.API.Instructor.Students
                      Handler.API.Instructor.Assignments
@@ -85,11 +87,13 @@ library
                 FlexibleInstances
                 EmptyDataDecls
                 LambdaCase
+                NamedFieldPuns
                 NoMonomorphismRestriction
                 RankNTypes
                 DeriveDataTypeable
                 ViewPatterns
                 TupleSections
+                TypeApplications
                 RecordWildCards
 
     build-depends: base >=4.8.2.0 && <4.9 || >=4.9.1.0 && <5
@@ -110,6 +114,7 @@ library
                  , persistent                    >=2.8 && <2.14
                  , persistent-postgresql         >=2.8 && <2.14
                  , persistent-sqlite
+                 , esqueleto
                  , template-haskell
                  , th-utilities
                  , shakespeare                   >= 2.0        && < 2.1

--- a/Carnap-Server/Carnap-Server.cabal
+++ b/Carnap-Server/Carnap-Server.cabal
@@ -100,28 +100,27 @@ library
                  , yesod-auth-lti13
                  , lti13
                  , yesod-static                  >=1.6 && <1.7
-                 , yesod-form                    >=1.6 && <1.7
+                 , yesod-form                    >=1.6 && <1.8
                  , yesod-markdown                >= 0.12
                  , classy-prelude                >=1.4 && <1.6
                  , classy-prelude-conduit        >=1.4 && <1.6
                  , classy-prelude-yesod          >=1.4 && <1.6
                  , bytestring                    >=0.9 && <0.11
                  , text                          >=0.11 && <2.0
-                 , persistent                    >=2.8 && <2.12
-                 , persistent-postgresql         >=2.8 && <2.12
+                 , persistent                    >=2.8 && <2.14
+                 , persistent-postgresql         >=2.8 && <2.14
                  , persistent-sqlite
-                 , persistent-template           >= 2.5        && < 2.10
                  , template-haskell
                  , th-utilities
                  , shakespeare                   >= 2.0        && < 2.1
                  , monad-control                 >= 0.3        && < 1.1
-                 , wai-extra                     >= 3.0        && < 3.1
+                 , wai-extra                     >= 3.0        && < 3.2
                  , yaml                          >= 0.8        && < 0.12
                  , http-conduit                  >= 2.3        && < 2.4
                  , directory                     >= 1.1        && < 1.4
                  , warp                          >= 3.0        && < 3.4
                  , data-default
-                 , aeson                         >= 0.6        && < 1.5
+                 , aeson                         >= 0.6        && < 1.6
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4
                  , fast-logger                   >= 2.2        && < 3.1
@@ -151,8 +150,8 @@ library
                  , tz
                  , tzdata
                  , random
-                 , cryptonite >= 0.26 && < 0.27
-                 , base64-bytestring >= 1.0.0 && < 1.1
+                 , cryptonite >= 0.26 && < 0.30
+                 , base64-bytestring >= 1.0.0 && < 1.2
                  , clock
                  , wai-middleware-throttle >= 0.3.0.0 && < 0.4
                  , Carnap-Client

--- a/Carnap-Server/Foundation.hs
+++ b/Carnap-Server/Foundation.hs
@@ -3,7 +3,6 @@ module Foundation where
 import qualified Control.Monad.Trans.Except as E
 import qualified Data.CaseInsensitive       as CI
 import qualified Data.HashMap.Strict        as HM
-import qualified Data.Map                   as Map
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as TE
 import qualified Data.Text.Encoding.Error   as TEE

--- a/Carnap-Server/Handler/API/AesonHelper.hs
+++ b/Carnap-Server/Handler/API/AesonHelper.hs
@@ -1,0 +1,11 @@
+module Handler.API.AesonHelper where
+import           Data.Char (toLower)
+import           Data.List (stripPrefix)
+import           Prelude
+
+-- | Remove prefix and leading uppercase letter
+unPrefix :: String -> String -> String
+unPrefix prefix text =
+    -- this code is bad on purpose, it will only crash at compile time
+    let Just (first:rest) = stripPrefix prefix text
+    in toLower first : rest

--- a/Carnap-Server/Handler/API/Instructor/Documents.hs
+++ b/Carnap-Server/Handler/API/Instructor/Documents.hs
@@ -1,47 +1,52 @@
 module Handler.API.Instructor.Documents where
 
 import           Data.Aeson
-import           Data.HashMap.Strict as HM
+import           Handler.API.Instructor.Types (DocumentPatch (..),
+                                               DocumentPost (..))
 import           Import
 import           System.Directory
 import           System.FilePath
-import           Util.Data           (SharingScope (..))
+import           Util.Data                    (SharingScope (..))
+import           Util.Database                (documentsWithTags)
 import           Util.Handler
 
 getAPIInstructorDocumentsR :: Text -> Handler Value
-getAPIInstructorDocumentsR ident = do Entity uid _ <- userFromIdent ident
-                                      docs <- runDB $ selectList [DocumentCreator ==. uid] []
-                                      returnJson docs
+getAPIInstructorDocumentsR ident = do
+    Entity uid _ <- userFromIdent ident
+    returnJson =<< runDB (documentsWithTags uid)
 
 postAPIInstructorDocumentsR :: Text -> Handler Value
-postAPIInstructorDocumentsR ident = do Entity uid _ <- userFromIdent ident
-                                       val <- requireCheckJsonBody :: Handler Value
-                                       time <- liftIO $ getCurrentTime
-                                       val' <- case val of
-                                                   Object hm ->
-                                                        let hm' = HM.insert "creator" (toJSON uid)
-                                                                . HM.insert "date" (toJSON time)
-                                                                --default to private if scope is omitted
-                                                                . HM.insertWith (\_ y -> y) "scope" (toJSON Private)
-                                                                $ hm
-                                                        in return $ Object hm'
-                                                   _ -> sendStatusJSON badRequest400 ("Improper JSON" :: Text)
-                                       case fromJSON val' :: Result Document of
-                                           Error e -> sendStatusJSON badRequest400 e
-                                           Success doc | badFileName (documentFilename doc) ->
-                                               sendStatusJSON badRequest400 ("Improper filename" :: Text)
-                                           Success doc -> do
-                                               dir <- docDir ident
-                                               liftIO $ createDirectoryIfMissing True dir
-                                               path <- docFilePath ident doc
-                                               liftIO (doesFileExist path) >>= --don't clobber and annex
-                                                   bool (return ()) (sendStatusJSON conflict409 ("A document with that name already exists." :: Text))
-                                               inserted <- runDB (insertUnique doc) >>=
-                                                           maybe (sendStatusJSON conflict409 ("A document with that name already exists." :: Text)) return
-                                               writeFile path " "
-                                               render <- getUrlRender
-                                               addHeader "Location" (render $ APIInstructorDocumentR ident inserted)
-                                               sendStatusJSON created201 inserted
+postAPIInstructorDocumentsR ident = do
+    Entity uid _ <- userFromIdent ident
+    DocumentPost {docPostScope, docPostFilename, docPostDescription, docPostTags}
+        <- requireCheckJsonBody :: Handler DocumentPost
+    time <- liftIO getCurrentTime
+
+    when (badFileName docPostFilename)
+        $ sendStatusJSON badRequest400 ("Improper filename" :: Text)
+    let doc = Document
+            { documentFilename = docPostFilename
+            , documentCreator = uid
+            , documentDate = time
+            , documentScope = fromMaybe Private docPostScope
+            , documentDescription = docPostDescription
+            }
+
+    dir <- docDir ident
+    liftIO $ createDirectoryIfMissing True dir
+    path <- docFilePath ident doc
+    liftIO (doesFileExist path) >>= --don't clobber and annex
+        flip when (sendStatusJSON conflict409 ("A document with that name already exists." :: Text))
+    inserted <- runDB $ do
+        docId <- insertUnique doc >>=
+            maybe (sendStatusJSON conflict409 ("A document with that name already exists." :: Text)) return
+        insertMany_ (Tag docId <$> concat docPostTags)
+        return docId
+    writeFile path " "
+    render <- getUrlRender
+    addHeader "Location" (render $ APIInstructorDocumentR ident inserted)
+    sendStatusJSON created201 inserted
+
     where badFileName s = takeFileName (unpack s) /= unpack s
 
 getAPIInstructorDocumentR :: Text -> DocumentId -> Handler Value
@@ -50,25 +55,22 @@ getAPIInstructorDocumentR ident docid = do Entity uid _ <- userFromIdent ident
                                            checkUID doc uid
                                            returnJson doc
 
-data DocumentPatch = DocumentPatch
-                        { patchScope       :: Maybe SharingScope
-                        , patchDescription :: Maybe (Maybe Text)
-                        }
-
-instance FromJSON DocumentPatch where
-        parseJSON = withObject "documentPatch" $ \o -> do
-            DocumentPatch <$> (o .:? "scope")
-                          <*> (o .:! "description")
-
 patchAPIInstructorDocumentR :: Text -> DocumentId -> Handler Value
-patchAPIInstructorDocumentR ident docid = do Entity uid _ <- userFromIdent ident
-                                             doc <- runDB (get docid) >>= maybe (sendStatusJSON notFound404 ("No such document" :: Text)) pure
-                                             checkUID doc uid
-                                             patch <- requireCheckJsonBody :: Handler DocumentPatch
-                                             doc' <- runDB $ updateGet docid
-                                                           $ maybeUpdate DocumentScope (patchScope patch)
-                                                          ++ maybeUpdate DocumentDescription (patchDescription patch)
-                                             returnJson doc'
+patchAPIInstructorDocumentR ident docid = do
+    Entity uid _ <- userFromIdent ident
+    doc <- runDB (get docid) >>= maybe (sendStatusJSON notFound404 ("No such document" :: Text)) pure
+    checkUID doc uid
+
+    DocumentPatch {patchScope, patchDescription, patchTags}
+        <- requireCheckJsonBody :: Handler DocumentPatch
+    doc' <- runDB $ do
+        putMany (Tag docid <$> concat patchTags)
+        updateGet docid
+              $ maybeUpdate DocumentScope patchScope
+             ++ maybeUpdate DocumentDescription patchDescription
+
+    returnJson doc'
+
     where maybeUpdate field (Just val) = [field =. val]
           maybeUpdate _     Nothing    = []
 

--- a/Carnap-Server/Handler/API/Instructor/Types.hs
+++ b/Carnap-Server/Handler/API/Instructor/Types.hs
@@ -1,0 +1,36 @@
+module Handler.API.Instructor.Types where
+import           Data.Aeson.TH           (defaultOptions, deriveFromJSON,
+                                          deriveToJSON, fieldLabelModifier)
+import           Handler.API.AesonHelper
+import           Import
+import           Util.Data               (SharingScope)
+
+data DocumentPost = DocumentPost
+    { docPostFilename    :: Text
+    , docPostDescription :: Maybe Text
+    , docPostScope       :: Maybe SharingScope
+    , docPostTags        :: Maybe [Text]
+    }
+
+$(deriveFromJSON
+    defaultOptions
+        {
+            fieldLabelModifier = unPrefix "docPost"
+        }
+    ''DocumentPost
+    )
+
+data DocumentPatch = DocumentPatch
+    { patchScope       :: Maybe SharingScope
+    , patchDescription :: Maybe (Maybe Text)
+    , patchTags        :: Maybe [Text]
+    }
+
+$(deriveFromJSON
+    defaultOptions
+        {
+            fieldLabelModifier = unPrefix "patch"
+        }
+    ''DocumentPatch
+    )
+

--- a/Carnap-Server/Handler/Common.hs
+++ b/Carnap-Server/Handler/Common.hs
@@ -1,8 +1,9 @@
 -- | Common handler functions.
 module Handler.Common where
 
-import Data.FileEmbed (embedFile)
-import Import
+import           Data.FileEmbed   (embedFile)
+import           Import
+import           TH.RelativePaths (pathRelativeToCabalPackage)
 
 -- These handlers embed files in the executable at compile time to avoid a
 -- runtime dependency, and for efficiency.
@@ -10,8 +11,8 @@ import Import
 getFaviconR :: Handler TypedContent
 getFaviconR = do cacheSeconds $ 60 * 60 * 24 * 30 -- cache for a month
                  return $ TypedContent "image/x-icon"
-                        $ toContent $(embedFile "config/favicon.ico")
+                        $ toContent $(embedFile =<< pathRelativeToCabalPackage "config/favicon.ico")
 
 getRobotsR :: Handler TypedContent
 getRobotsR = return $ TypedContent typePlain
-                    $ toContent $(embedFile "config/robots.txt")
+                    $ toContent $(embedFile =<< pathRelativeToCabalPackage "config/robots.txt")

--- a/Carnap-Server/Import/NoFoundation.hs
+++ b/Carnap-Server/Import/NoFoundation.hs
@@ -25,6 +25,7 @@ type PersistentSite site =
      YesodAuthPersist site,
      AuthId site ~ Key User,
      AuthEntity site ~ User,
-     BaseBackend (YesodPersistBackend site) ~ SqlBackend
+     BaseBackend (YesodPersistBackend site) ~ SqlBackend,
+     BackendCompatible SqlBackend (YesodPersistBackend site)
      )
 

--- a/Carnap-Server/Model.hs
+++ b/Carnap-Server/Model.hs
@@ -45,3 +45,8 @@ instance ToJSON Course where
                           , "enrollmentOpen" .= courseEnrollmentOpen c
                           , "timeZone" .= (decodeUtf8 $ courseTimeZone c :: Text)
                           ]
+
+-- no instance Hashable for DocumentId and I want a hashmap...
+instance Hashable DocumentId where
+    hash = fromIntegral . toBackendKey
+    hashWithSalt salt v = hashWithSalt salt (hash v)

--- a/Carnap-Server/Model.hs
+++ b/Carnap-Server/Model.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/Carnap-Server/Util/Database.hs
+++ b/Carnap-Server/Util/Database.hs
@@ -186,15 +186,6 @@ classesByInstructorIdent ident = runDB $ do
                    return (owned ++ coOwned)
                Nothing -> return []
 
-documentsByInstructorIdent
-    :: PersistentSite site
-    => Text
-    -> HandlerFor site [Entity Document]
-documentsByInstructorIdent ident = runDB $ do muent <- getBy $ UniqueUser ident
-                                              case entityKey <$> muent of
-                                                  Just uid -> selectList [DocumentCreator ==. uid] []
-                                                  Nothing -> return []
-
 -- | old derived rules by userId XXX: legacy, deprecate eventually
 getDerivedRules
     :: PersistentSite site
@@ -302,4 +293,15 @@ documentsWithTags uid = do
         docs = foldl' concatIdentical HM.empty (toDocumentGet <$> docsWithTags)
     -- and finally return the stuck together ones
     return $ HM.elems docs
+
+documentsByInstructorIdent
+    :: PersistentSite site
+    => Text
+    -> HandlerFor site [DocumentGet]
+documentsByInstructorIdent ident =
+    runDB $ do
+        muent <- getBy $ UniqueUser ident
+        case entityKey <$> muent of
+            Just uid -> documentsWithTags uid
+            Nothing -> return []
 

--- a/Carnap-Server/templates/instructor.hamlet
+++ b/Carnap-Server/templates/instructor.hamlet
@@ -142,23 +142,22 @@
                                 <th> Tags
                                 <th> Actions
                             <tbody>
-                                $forall Entity k a <- documents
-                                    <tr id="document-#{documentFilename a}">
+                                $forall d <- documents
+                                    <tr id="document-#{docGetFilename d}">
                                         <td>
-                                            <a href="@{DocumentR ident (documentFilename a)}">
-                                                #{documentFilename a}
-                                        <td> #{formatTime defaultTimeLocale "%F" $ documentDate a}
-                                        <td> #{show $ documentScope a}
+                                            <a href="@{DocumentR ident (docGetFilename d)}">
+                                                #{docGetFilename d}
+                                        <td> #{formatTime defaultTimeLocale "%F" $ docGetDate d}
+                                        <td> #{show $ docGetScope d}
                                         <td>
-                                            $maybe tags <- tagsOf k
-                                                $forall tag <- tags
-                                                    <a.badge.badge-primary href="@{DocumentsByTagR tag}">#{tag}
+                                            $forall tag <- docGetTags d
+                                                <a.badge.badge-primary href="@{DocumentsByTagR tag}">#{tag}
                                         <td>
-                                            <button.btn.btn-sm.btn-secondary type="button" alt="delete" title="permanently delete this document" onclick="tryDeleteDocument('#{jsonSerialize $ DeleteDocument (documentFilename a)}')">
+                                            <button.btn.btn-sm.btn-secondary type="button" alt="delete" title="permanently delete this document" onclick="tryDeleteDocument('#{jsonSerialize $ DeleteDocument (docGetFilename d)}')">
                                                 <i.fa.fa-trash-o>
-                                            <button.btn.btn-sm.btn-secondary type="button" alt="edit" title="edit this document" onclick="modalEditDocument('#{show k}','#{maybe "" sanitizeForJS (unpack <$> documentDescription a)}','#{documentFilename a}', '#{tagString k}')">
+                                            <button.btn.btn-sm.btn-secondary type="button" alt="edit" title="edit this document" onclick="modalEditDocument('#{show $ docGetId d}','#{maybe "" sanitizeForJS (unpack <$> docGetDescription d)}','#{docGetFilename d}', '#{tagString d}')">
                                                 <i.fa.fa-cog>
-                                            <button.btn.btn-sm.btn-secondary alt="download" title="download this document" type="button" onclick="window.open('@{DocumentDownloadR ident (documentFilename a)}')">
+                                            <button.btn.btn-sm.btn-secondary alt="download" title="download this document" type="button" onclick="window.open('@{DocumentDownloadR ident (docGetFilename d)}')">
                                                 <i.fa.fa-cloud-download>
                     <hr>
                     <dl.row>

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 { ghcjsVer ? "ghcjs",
-  ghcVer ? "ghc884",
+  ghcVer ? "ghc8106",
   profiling ? false,
   hls ? false,
 }:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "nixpkgs": {
-        "branch": "nixpkgs-unstable",
+        "branch": "haskell-updates",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ca3fa9c32a45f028f480ab8ec26cc4bd8ce800ad",
-        "sha256": "06brxwypbsp1y2m9ppprkwsjg60jjp6bs2mmx7s8imk32pw86vi9",
+        "rev": "3440070b83ffdf2ecd787dfc5542374e9ad06ec0",
+        "sha256": "1nycrgv24qarv2vxy35jpyxd1ji7v3ndblpb655f31zhnq8syl93",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ca3fa9c32a45f028f480ab8ec26cc4bd8ce800ad.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/3440070b83ffdf2ecd787dfc5542374e9ad06ec0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-stable": {

--- a/server.nix
+++ b/server.nix
@@ -12,52 +12,29 @@ let
     overrideCabal;
 in
 newpkgs: oldpkgs: {
-  # TODO: This has actually been fixed as of 2021-01-09 but it probably hasn't
-  # got into our nixpkgs. Need to update that.
-  # downgrade to 1.8.x because yesod-auth-oauth2 has not fixed support for
-  # newer versions in any *released* version yet
-  hoauth2 = oldpkgs.callHackage "hoauth2" "1.8.9" { };
-
-  # update to fix a possible security bug: https://github.com/thoughtbot/yesod-auth-oauth2/issues/132
-  yesod-auth-oauth2 = oldpkgs.callHackageDirect {
-    pkg = "yesod-auth-oauth2";
-    ver = "0.6.1.3";
-    sha256 = "1bikn9kfw6mrsais4z1nk07aa7i7hyrcs411kbbfgc7n74k6sd5b";
-  } { };
-
   # failing tests on macOS for some reason:
   # https://github.com/ubc-carnap-team/Carnap/runs/1074093219?check_suite_focus=true
   tz = dontCheck oldpkgs.tz;
-
-  # Use the version from https://github.com/yesodweb/persistent/pull/1106
-  # using overrideSrc to maintain dependency relations and nix's fixes/overrides for these
-  persistent = overrideSrc oldpkgs.persistent { src = (persistent + "/persistent"); };
-  persistent-sqlite = overrideSrc oldpkgs.persistent-sqlite { src = (persistent + "/persistent-sqlite"); };
-  # this one we have to recreate from scratch anyway because they added a dependency
-  persistent-postgresql = dontCheck (oldpkgs.callCabal2nix "persistent-postgresql" (persistent + "/persistent-postgresql") { });
-  persistent-template = overrideSrc oldpkgs.persistent-template { src = (persistent + "/persistent-template"); };
-  persistent-qq = overrideSrc oldpkgs.persistent-qq { src = (persistent + "/persistent-qq"); };
-  persistent-test = overrideSrc oldpkgs.persistent-test { src = (persistent + "/persistent-test"); };
-  # too tight an upper version bound on persistent
-  yesod-persistent = doJailbreak oldpkgs.yesod-persistent;
-  yesod-auth = doJailbreak oldpkgs.yesod-auth;
 
   # they wrote a spec that calls out to Google. It does not work in a nix
   # builder.
   oidc-client = dontCheck oldpkgs.oidc-client;
 
-  # lti13 and yesod-auth-lti13 are not in nixpkgs yet
+  # lti13 and yesod-auth-lti13 are not in all-hashes yet, 99% of the time, so
+  # just manually pull them...
+  #
+  # Development overrides:
   # lti13 = oldpkgs.callCabal2nix "lti13" ../lti13/lti13 { };
   # yesod-auth-lti13 = oldpkgs.callCabal2nix "yesod-auth-lti13" ../lti13/yesod-auth-lti13 { };
   lti13 = oldpkgs.callHackageDirect {
     pkg = "lti13";
-    ver = "0.2.0.2";
-    sha256 = "014pmhl28z242pmmkn63sh7ijdjlh2f7fbq8l5bc0q6llcd6if7y";
+    ver = "0.2.0.3";
+    sha256 = "0hwsrag4skck992hnzmj5n5iclbbrbwdwa5rxsrks8ins7jgrg1f";
   } { };
   yesod-auth-lti13 = oldpkgs.callHackageDirect {
     pkg = "yesod-auth-lti13";
-    ver = "0.2.0.2";
-    sha256 = "0q2vy7zdv5sm09wh2cqslgz0yh8l4h2gd7w1024i2mgblxa8v4xw";
+    ver = "0.2.0.3";
+    sha256 = "0mmhznyzjaqmbcgvcznab2sx5ghaxv66cxq07b8yimg61yfadbgb";
   } { };
 
   # dontCheck: https://github.com/gleachkr/Carnap/issues/123

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,38 +1,22 @@
 flags: {}
 extra-package-dbs: []
 extra-deps:
-    - yesod-markdown-0.12.6.3
-    - yesod-auth-oauth2-0.6.1.3
-    - hoauth2-1.8.9
-    # - uri-bytestring-aeson-0.1.0.8
-    - diagrams-builder-0.8.0.5
-    - tz-0.1.3.4@sha256:bd311e202b8bdd15bcd6a4ca182e69794949d3b3b9f4aa835e9ccff011284979,5086
-    - th-utilities-0.2.4.0@sha256:ba19cd8441aa43dbaed40e9055bb5a7cbd7cf9e154f5253c6bf9293af8b1f96b,1869
-    - haskell-src-exts-simple-1.22.0.0
-    - haskell-src-exts-1.22.0
+    - yesod-markdown-0.12.6.11
+    - yesod-auth-oauth2-0.6.3.4
+    - hoauth2-1.16.0
+    - tz-0.1.3.5
+    - th-utilities-0.2.4.3
+    - haskell-src-exts-simple-1.23.0.0
+    - haskell-src-exts-1.23.1
     - wai-middleware-throttle-0.3.0.1@sha256:8da81c156abbcaee3bdda60763bb9780ae1b9ff447bd5580202c0e0f5f8f7bcb,2522
-    - token-bucket-0.1.0.1@sha256:ef80a31e7f4f794e3686eb405a49afc663535dd3a11c012a002a7bacce897da6,1912
-    - git: https://github.com/yesodweb/persistent.git
-      commit: 1cdadc10405e9e3b1e0e73e2c1d6ec84eed69a53
-      subdirs:
-          - persistent
-          - persistent-sqlite
-          - persistent-postgresql
-          - persistent-template
-          - persistent-qq
-    - lti13-0.2.0.2
-    - yesod-auth-lti13-0.2.0.2
-    - oidc-client-0.5.1.0
-
-# :( persistent bug fix requires a git version, which means we have to turn off
-# version checking in every yesod project
-allow-newer: true
+    - token-bucket-0.1.0.1
+    - lti13-0.2.0.3
+    - yesod-auth-lti13-0.2.0.3
+    - oidc-client-0.6.0.0
+    - classy-prelude-yesod-1.5.0
 
 packages:
 - Carnap/
 - Carnap-Server/
 - Carnap-Client/
-#resolver: lts-6.25
-#resolver: lts-12.26
-#resolver: lts-14.27
-resolver: lts-16.11
+resolver: lts-18.7


### PR DESCRIPTION
This is based on #283.

**Interesting changes**:
* Added Esqueleto for writing type safe SQL queries
* Refactored Instructor to not do O(n) SQL queries while getting documents with tags, instead using a join.