### PR TITLE
Majda/modelcheckingsetbrackets

### DIFF
--- a/Carnap-Book/chapter13.pandoc
+++ b/Carnap-Book/chapter13.pandoc
@@ -1,0 +1,26 @@
+# Model Checking Module Tests (ADDED FOR DEV): Give a model that makes the following formula **false**:
+
+In the following exercises, you will practice the creation of models that make a formula false.
+# All domains contain set brackets
+
+# .Simple
+# Set brackets around functions
+```{.CounterModeler .Simple}
+1.1 AxAy(f(x,y) = f(y,x))
+```
+
+# .Validity
+# Set brackets around predicates
+```{.CounterModeler .Validity}
+1.2 AxEyF(x,y) :|-: ExAyF(y,x)
+```
+
+# .Constraint
+```{.CounterModeler .Constraint }
+1.3 ExEy(not x = y) : AxAyF(x,y)
+```
+
+# Constants not sets
+~~~{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" points=1}
+  M(p) /\ L(p,m)
+~~~

--- a/Carnap-Book/chapter13.pandoc
+++ b/Carnap-Book/chapter13.pandoc
@@ -1,10 +1,9 @@
-# Model Checking Module Tests (ADDED FOR DEV): Give a model that makes the following formula **false**:
+# Model Checking Module Tests (added for dev):
 
-### Quick view of functionality:
-### All domains contain set brackets
+## Quick view of functionality:
 
 ## .Simple
-### Set brackets around functions
+### Set brackets around functions and domain
 ```{.CounterModeler .Simple}
 1.1 AxAy(f(x,y) = f(y,x))
 ```
@@ -15,12 +14,13 @@
 ~~~
 
 ## .Validity
-### Set brackets around predicates
+### Set brackets around predicates and domain
 ```{.CounterModeler .Validity}
 1.2 AxEyF(x,y) :|-: ExAyF(y,x)
 ```
 
 ## .Constraint
+### set brackets around predicates and domain
 ```{.CounterModeler .Constraint }
 1.3 ExEy(not x = y) : AxAyF(x,y)
 ```

--- a/Carnap-Book/chapter13.pandoc
+++ b/Carnap-Book/chapter13.pandoc
@@ -1,5 +1,6 @@
 # Model Checking Module Tests (ADDED FOR DEV): Give a model that makes the following formula **false**:
 
+# Quick view of functionality:
 In the following exercises, you will practice the creation of models that make a formula false.
 # All domains contain set brackets
 
@@ -24,3 +25,149 @@ In the following exercises, you will practice the creation of models that make a
 ~~~{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" points=1}
   M(p) /\ L(p,m)
 ~~~
+
+# More tests (found online)
+
+```{.CounterModeler .Simple}
+1.1 AxF(x), ExG(x)
+```
+~~~{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" points=1}
+  M(p) /\ L(p,m)
+~~~
+**A solution:** Domain: [ 0, 1 ]&nbsp;&nbsp;&nbsp; M(_): [ 0 ]&nbsp;&nbsp;&nbsp; p: [ 0 ]&nbsp;&nbsp;&nbsp; m: [ 1 ] &nbsp;&nbsp;&nbsp; L: [  ]
+<br>
+<br>
+
+<span style="color: blue;font-size:20pt">**Exercises**</span>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+B.  M(p)
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+1.  M(p) /\ M(m)
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+2.  M(p) /\ ~M(m)
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+3.  ~M(p) /\ ~M(m)
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+4.  ~(M(p) \/ ~M(m))
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+5.  ~M(p) \/ ~M(m)
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+6.  (M(p) /\ F(m)) -> L(p,m)
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+7.   L(m,p) <-> L(p,m)
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+8.   M(o) /\ (~M(o) \/ S(o))
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+9.   M(o) \/ (~M(o) /\ S(o))
+```
+
+<br>
+
+#### Give a model that makes the following formula **false**:
+
+<p style="color: red;font-size:13pt">
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;KEY:&nbsp;p Peter &nbsp;&nbsp;o Otto &nbsp;&nbsp;m Maria &nbsp;&nbsp;c Clara &nbsp;&nbsp;M Mann &nbsp;&nbsp;S schlafen &nbsp;&nbsp;F Frau &nbsp;&nbsp;L lieben 
+</p>
+
+```{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" submission="none"}
+10.   L(m,m) <-> L(p,p)
+```
+
+<br>

--- a/Carnap-Book/chapter13.pandoc
+++ b/Carnap-Book/chapter13.pandoc
@@ -1,30 +1,29 @@
 # Model Checking Module Tests (ADDED FOR DEV): Give a model that makes the following formula **false**:
 
-# Quick view of functionality:
-In the following exercises, you will practice the creation of models that make a formula false.
-# All domains contain set brackets
+### Quick view of functionality:
+### All domains contain set brackets
 
-# .Simple
-# Set brackets around functions
+## .Simple
+### Set brackets around functions
 ```{.CounterModeler .Simple}
 1.1 AxAy(f(x,y) = f(y,x))
 ```
 
-# .Validity
-# Set brackets around predicates
+### Constants not sets
+~~~{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" points=1}
+  M(p) /\ L(p,m)
+~~~
+
+## .Validity
+### Set brackets around predicates
 ```{.CounterModeler .Validity}
 1.2 AxEyF(x,y) :|-: ExAyF(y,x)
 ```
 
-# .Constraint
+## .Constraint
 ```{.CounterModeler .Constraint }
 1.3 ExEy(not x = y) : AxAyF(x,y)
 ```
-
-# Constants not sets
-~~~{.CounterModeler .Simple counterexample-to="validity" system="thomasBolducAndZachFOL2019" points=1}
-  M(p) /\ L(p,m)
-~~~
 
 # More tests (found online)
 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/CounterModel.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/CounterModel.hs
@@ -275,7 +275,7 @@ prepareModelUI w fs (i,o) mdl bw opts = do
            -- append closing set bracket to domain label
            mapM (appendChild domainLabel . Just) [domainInput, domainWarn, closingBracketSpan]
            
-           mapM (appendChild o . Just) [domainLabel]
+           appendChild o (Just domainLabel)
 
            appendRelationInputs w o opts fs mdl
            appendPropInputs w o opts fs mdl

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/CounterModel.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/CounterModel.hs
@@ -262,13 +262,21 @@ prepareModelUI :: ModelingLanguage lex => Document -> [FixLang lex (Form Bool)] 
     -> IO ()
 prepareModelUI w fs (i,o) mdl bw opts = do
            Just domainLabel <- createElement w (Just "label")
-           setInnerHTML domainLabel $ Just (if "forallxStyle" `inOpts` opts then "UD = " else "Domain: ")
+           setInnerHTML domainLabel $ Just (if "forallxStyle" `inOpts` opts then "UD = " else "Domain: {  ")
            (domainInput,domainWarn) <- parsingInput w things domainUpdater
            setAttribute domainInput "name" "Domain"
            setAttribute domainInput "rows" "1"
            setValue (castToHTMLTextAreaElement domainInput) (Just "0")
            mapM (appendChild domainLabel . Just) [domainInput, domainWarn]
-           appendChild o (Just domainLabel)
+           
+           Just closingBracketSpan <- createElement w (Just "span")
+           setInnerHTML closingBracketSpan $ Just "}"
+
+           --appendChild o (Just domainLabel)
+           mapM (appendChild domainLabel . Just)[closingBracketSpan]
+
+           mapM (appendChild o . Just) [domainLabel]
+
            appendRelationInputs w o opts fs mdl
            appendPropInputs w o opts fs mdl
            let ts = concatMap (toListOf termsOf) fs
@@ -363,13 +371,20 @@ getRelationInput w opts f mdl = case addRelation f mdl [] of
                                              Just relationLabel <- createElement w (Just "label")
                                              setInnerHTML relationLabel $ Just $ if "forallxStyle" `inOpts` opts 
                                                                             then "extension(" ++ [head (show $ blankTerms f)] ++ ") = "
-                                                                            else show (blankTerms f) ++ ": "
+                                                                            else show (blankTerms f) ++ ": { "
                                              (relationInput,parseWarn) <- parsingInput w (ntuples n) relationUpdater
                                              setAttribute relationInput "name" (show (blankTerms f))
                                              setAttribute relationInput "rows" "1"
                                              setAttribute relationInput "class" "relationInput"
                                              appendChild relationLabel (Just relationInput)
                                              appendChild relationLabel (Just parseWarn)
+S
+                                             -- Append the closing curly brace
+                                             Just closingBracketSpan <- createElement w (Just "span")
+                                             setInnerHTML closingBracketSpan $ Just "}" 
+
+                                             appendChild relationLabel (Just closingBracketSpan)
+
                                              return $ Just relationLabel
     where relationUpdater ext = case addRelation f mdl ext of
                                      Just io -> liftIO io >> return ()
@@ -386,13 +401,21 @@ getFunctionInput w opts f mdl = case addFunction f mdl [] of
                                                 Just functionLabel <- createElement w (Just "label")
                                                 setInnerHTML functionLabel $ Just $ if "forallxStyle" `inOpts` opts
                                                                                         then "extension(" ++ [head (show $ blankFuncTerms f)] ++ ") = "
-                                                                                        else show (blankFuncTerms f) ++ ": "
+                                                                                        else show (blankFuncTerms f) ++ ": {"
                                                 (functionInput,parseWarn) <- parsingInput w (nfunctuples (n + 1)) functionUpdater
                                                 setAttribute functionInput "name" (show (blankFuncTerms f))
                                                 setAttribute functionInput "rows" "1"
                                                 setAttribute functionInput "class" "functionInput"
                                                 appendChild functionLabel (Just functionInput)
                                                 appendChild functionLabel (Just parseWarn)
+
+                                                 -- Append the closing curly brace
+                                                Just closingBracketSpan <- createElement w (Just "span")
+                                                setInnerHTML closingBracketSpan $ Just "}" 
+
+                                                appendChild functionLabel (Just closingBracketSpan)
+
+                                             
                                                 return $ Just functionLabel
     where functionUpdater ext = case addFunction f mdl ext of
                                      Just io -> liftIO io >> return ()

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/CounterModel.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/CounterModel.hs
@@ -378,7 +378,7 @@ getRelationInput w opts f mdl = case addRelation f mdl [] of
                                              setAttribute relationInput "class" "relationInput"
                                              appendChild relationLabel (Just relationInput)
                                              appendChild relationLabel (Just parseWarn)
-S
+
                                              -- create the closing set bracket
                                              Just closingBracketSpan <- createElement w (Just "span")
                                              setInnerHTML closingBracketSpan $ Just "}" 

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/CounterModel.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/CounterModel.hs
@@ -267,14 +267,14 @@ prepareModelUI w fs (i,o) mdl bw opts = do
            setAttribute domainInput "name" "Domain"
            setAttribute domainInput "rows" "1"
            setValue (castToHTMLTextAreaElement domainInput) (Just "0")
-           mapM (appendChild domainLabel . Just) [domainInput, domainWarn]
            
+           -- create closing set bracket
            Just closingBracketSpan <- createElement w (Just "span")
            setInnerHTML closingBracketSpan $ Just "}"
 
-           --appendChild o (Just domainLabel)
-           mapM (appendChild domainLabel . Just)[closingBracketSpan]
-
+           -- append closing set bracket to domain label
+           mapM (appendChild domainLabel . Just) [domainInput, domainWarn, closingBracketSpan]
+           
            mapM (appendChild o . Just) [domainLabel]
 
            appendRelationInputs w o opts fs mdl
@@ -379,10 +379,11 @@ getRelationInput w opts f mdl = case addRelation f mdl [] of
                                              appendChild relationLabel (Just relationInput)
                                              appendChild relationLabel (Just parseWarn)
 S
-                                             -- Append the closing curly brace
+                                             -- create the closing set bracket
                                              Just closingBracketSpan <- createElement w (Just "span")
                                              setInnerHTML closingBracketSpan $ Just "}" 
 
+                                             -- append the closing set bracket to the relation label
                                              appendChild relationLabel (Just closingBracketSpan)
 
                                              return $ Just relationLabel
@@ -409,10 +410,11 @@ getFunctionInput w opts f mdl = case addFunction f mdl [] of
                                                 appendChild functionLabel (Just functionInput)
                                                 appendChild functionLabel (Just parseWarn)
 
-                                                 -- Append the closing curly brace
+                                                 -- create the closing set bracket
                                                 Just closingBracketSpan <- createElement w (Just "span")
                                                 setInnerHTML closingBracketSpan $ Just "}" 
 
+                                                -- append the closing set bracket to the function label
                                                 appendChild functionLabel (Just closingBracketSpan)
 
                                              

--- a/Carnap-GHCJS/src/Carnap/GHCJS/Action/TruthTable.hs
+++ b/Carnap-GHCJS/src/Carnap/GHCJS/Action/TruthTable.hs
@@ -21,8 +21,6 @@ import GHCJS.DOM.Window (alert, prompt)
 import GHCJS.DOM.Document (createElement, getDefaultView)
 import GHCJS.DOM.Node (appendChild, getParentNode, getParentElement, insertBefore)
 import GHCJS.DOM.EventM (newListener, addListener, EventM, target)
-import GHCJS.DOM.HTMLInputElement(setValue)
-import GHCJS.DOM.HTMLCollection
 import Data.IORef (newIORef, IORef, readIORef,writeIORef, modifyIORef)
 import Data.Map as M (Map, lookup, foldr, insert, fromList, toList)
 import Data.Text (pack)


### PR DESCRIPTION
* For Model Checking Module (.CounterModeler). 
* The domain, predicates, and functions are now represented as sets. Constants are not represented as sets.
* Chapter 13 was added to Book with some examples to demonstrate functionality.
* Link to relevant story: https://app.clickup.com/t/8678y86yz 