### PR TITLE
Add Boolean constants to Gallow PL parser

### DIFF
--- a/Carnap/src/Carnap/Languages/PureFirstOrder/Parser.hs
+++ b/Carnap/src/Carnap/Languages/PureFirstOrder/Parser.hs
@@ -171,6 +171,7 @@ gallowPLParserOptions = magnusFOLParserOptions { freeVarParser = parseFreeVar "w
                                                           <|> try (sentenceLetterParser "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
                                              , opTable = calgaryOpTable
                                              , finalValidation = \x -> if isOpenFormula x then unexpected "unbound variable" else return ()
+                                             , hasBooleanConstants = True
                                              }
 
 gamutNDParserOptions :: FirstOrderParserOptions PureLexiconFOL u Identity


### PR DESCRIPTION
Predicate logic proofs in the _for all x_: Pittsburgh (Gallow) system allow Boolean constants (see [for all x: Pittsburgh](http://jdmitrigallow.com/teaching/logic19/text.pdf) ch. 33 p. 194), unlike their 'ancestor' proofs in _for all x_ (Magnus). However, these constants are not allowed in Carnap. Note that Carnap does allow Boolean constants for propositional logic proofs in the _for all x_: Pittsburgh system (see https://github.com/Carnap/Carnap/blob/master/Carnap/src/Carnap/Languages/PurePropositional/Parser.hs#L87).

This PR adds Boolean constants to _for all x_: Pittsburgh predicate logic proofs in Carnap.