### PR TITLE
Fix an off-by-one error in subproof range size check

### DIFF
--- a/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/StructuredFitch.hs
+++ b/Carnap/src/Carnap/Calculi/NaturalDeduction/Parser/StructuredFitch.hs
@@ -44,7 +44,7 @@ toProofTreeStructuredFitch t n = case t .! n of
                       subproofProcess (ProofType assumptionNumber conclusionNumber) deps = 
                         case filter (\(x,y) -> x /= y) deps of
                             [thesp@(first,last)] -> case range first last t of
-                                Just (SubProof _ ls) | (last - first) < (assumptionNumber + conclusionNumber) -> err "this subproof doesn't have enough lines to apply this rule"
+                                Just (SubProof _ ls) | (last - first + 1) < (assumptionNumber + conclusionNumber) -> err "this subproof doesn't have enough lines to apply this rule"
                                                      | let firstlines :: Inference r lex sem => DeductionTree r lex sem -> [Maybe (DeductionLine r lex sem)]
                                                            firstlines z =  map (\x -> z .! x) (take assumptionNumber [first ..]) 
                                                            badLine (Just l) = not $ isAssumptionLine l


### PR DESCRIPTION
Currently, the subproof range size check for Structured Fitch proofs is off by 1 line. This PR adds a `+ 1` to get the correct number of assumption and conclusion lines in a subproof.